### PR TITLE
fix(contract): widen BAD_REQUEST mapping except csrf framework exceptions

### DIFF
--- a/Backend/src/main/java/com/animalleague/april/common/infrastructure/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/animalleague/april/common/infrastructure/GlobalExceptionHandler.java
@@ -216,7 +216,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(
             ErrorResponse.of(
                 statusCode,
-                resolveFrameworkErrorCode(exception),
+                resolveFrameworkErrorCode(exception, statusCode),
                 resolveFrameworkMessage(exception),
                 path
             ),
@@ -253,7 +253,11 @@ public class GlobalExceptionHandler {
         return HttpHeaders.EMPTY;
     }
 
-    private String resolveFrameworkErrorCode(Exception exception) {
+    private String resolveFrameworkErrorCode(Exception exception, HttpStatusCode statusCode) {
+        if (statusCode.value() == HttpStatus.BAD_REQUEST.value() && !isCsrfException(exception)) {
+            return "BAD_REQUEST";
+        }
+
         if (exception instanceof NoResourceFoundException) {
             return "NOT_FOUND";
         }
@@ -275,6 +279,10 @@ public class GlobalExceptionHandler {
         }
 
         return "FRAMEWORK_ERROR";
+    }
+
+    private boolean isCsrfException(Exception exception) {
+        return exception.getClass().getName().startsWith("org.springframework.security.web.csrf");
     }
 
     private String resolveFrameworkMessage(Exception exception) {

--- a/Backend/src/test/java/com/animalleague/april/contract/support/ApiContractSmokeContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/support/ApiContractSmokeContractTest.java
@@ -59,4 +59,11 @@ class ApiContractSmokeContractTest extends ApiContractTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
+
+    @Test
+    void frameworkBadRequestErrorResponseKeepsBadRequestCode() throws Exception {
+        mockMvc.perform(get("/contract-smoke/error-response-bad-request"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+    }
 }

--- a/Backend/src/test/java/com/animalleague/april/contract/support/ContractSmokeController.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/support/ContractSmokeController.java
@@ -1,6 +1,8 @@
 package com.animalleague.april.contract.support;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.ErrorResponseException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,5 +25,10 @@ public class ContractSmokeController {
     @PostMapping(path = "/contract-smoke", consumes = MediaType.APPLICATION_JSON_VALUE)
     String smokeWithJson(@RequestBody String payload) {
         return payload;
+    }
+
+    @GetMapping("/contract-smoke/error-response-bad-request")
+    String smokeWithFrameworkBadRequestErrorResponse() {
+        throw new ErrorResponseException(HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
### Motivation
- Address a narrow bad-request mapping that missed framework-originated HTTP 400 responses by ensuring framework 400s are mapped to the `BAD_REQUEST` error code by default while keeping CSRF-related framework exceptions excluded. 
- Add a reproducible contract smoke case to ensure framework-produced 400 responses preserve the `BAD_REQUEST` code.

### Description
- Broadened framework error code resolution in `Backend/src/main/java/com/animalleague/april/common/infrastructure/GlobalExceptionHandler.java` to map responses with HTTP status 400 to `BAD_REQUEST` unless the exception is a Spring Security CSRF exception, implemented via a new `isCsrfException` check and changing `resolveFrameworkErrorCode` signature to accept the resolved status. 
- Added a smoke endpoint `GET /contract-smoke/error-response-bad-request` in `Backend/src/test/java/com/animalleague/april/contract/support/ContractSmokeController.java` that throws `ErrorResponseException(HttpStatus.BAD_REQUEST)` to reproduce the previously unmapped case. 
- Added a contract test `frameworkBadRequestErrorResponseKeepsBadRequestCode` in `Backend/src/test/java/com/animalleague/april/contract/support/ApiContractSmokeContractTest.java` to assert the framework-originated 400 response returns `$.code = BAD_REQUEST`.

### Testing
- Executed the targeted contract test using `cd Backend && ./gradlew --no-daemon contractTest --tests "*ApiContractSmokeContractTest.frameworkBadRequestErrorResponseKeepsBadRequestCode"` during the Red-Green loop and used the failure to guide the fix. 
- Ran the full contract suite with `cd Backend && ./gradlew --no-daemon contractTest` after the fix and the contract tests completed successfully. 
- No other automated test failures were observed in the contract test suite after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dfed7830832287476207e968d333)

## Summary by Sourcery

Ensure framework-originated HTTP 400 responses are consistently mapped to the BAD_REQUEST error code while excluding CSRF-related exceptions, and add contract coverage for this behavior.

Bug Fixes:
- Map generic framework 400 responses to the BAD_REQUEST error code, excluding Spring Security CSRF exceptions to preserve their existing behavior.

Tests:
- Extend contract smoke tests with a new endpoint and assertion to verify framework-produced 400 responses return code BAD_REQUEST.