### PR TITLE
feat(backend): 교수 등록과 호감도 코어 구현

### DIFF
--- a/Backend/build.gradle.kts
+++ b/Backend/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
@@ -85,6 +86,14 @@ integrationTest.configure {
                 commandLine("docker", "info")
             }.result.get()
         }
+    }
+    testLogging {
+        events("failed")
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = true
     }
 }
 

--- a/Backend/build.gradle.kts
+++ b/Backend/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.gradle.api.tasks.testing.Test
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
@@ -86,14 +85,6 @@ integrationTest.configure {
                 commandLine("docker", "info")
             }.result.get()
         }
-    }
-    testLogging {
-        events("failed")
-        showExceptions = true
-        showCauses = true
-        showStackTraces = true
-        exceptionFormat = TestExceptionFormat.FULL
-        showStandardStreams = true
     }
 }
 

--- a/Backend/src/main/java/com/animalleague/april/common/infrastructure/config/PersistenceConfig.java
+++ b/Backend/src/main/java/com/animalleague/april/common/infrastructure/config/PersistenceConfig.java
@@ -1,14 +1,17 @@
 package com.animalleague.april.common.infrastructure.config;
 
 import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Optional;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @EnableTransactionManagement
 public class PersistenceConfig {
 
@@ -16,5 +19,9 @@ public class PersistenceConfig {
     public Clock systemClock() {
         return Clock.systemUTC();
     }
-}
 
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider(Clock systemClock) {
+        return () -> Optional.of(OffsetDateTime.now(systemClock));
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/AffectionResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/AffectionResponse.java
@@ -1,0 +1,12 @@
+package com.animalleague.april.professor.api;
+
+import java.util.UUID;
+
+import com.animalleague.april.professor.domain.Affection;
+
+public record AffectionResponse(UUID professorId, int affectionScore) {
+
+    public static AffectionResponse from(Affection affection) {
+        return new AffectionResponse(affection.getProfessorId(), affection.getAffectionScore());
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/CharacterAssetResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/CharacterAssetResponse.java
@@ -1,0 +1,4 @@
+package com.animalleague.april.professor.api;
+
+public record CharacterAssetResponse(String variantKey, String imageUrl, boolean isDefaultAsset) {
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorController.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorController.java
@@ -1,0 +1,44 @@
+package com.animalleague.april.professor.api;
+
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animalleague.april.professor.application.ProfessorService;
+
+@RestController
+@RequestMapping("/api/professors")
+public class ProfessorController {
+
+    private final ProfessorService professorService;
+
+    public ProfessorController(ProfessorService professorService) {
+        this.professorService = professorService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProfessorCreateResponse> createProfessor(
+        @Valid @RequestBody ProfessorCreateRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(professorService.createProfessor(request));
+    }
+
+    @GetMapping
+    public ProfessorListResponse listProfessors() {
+        return professorService.listProfessors();
+    }
+
+    @GetMapping("/{professorId}")
+    public ProfessorDetailResponse getProfessorDetail(@PathVariable UUID professorId) {
+        return professorService.getProfessorDetail(professorId);
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateRequest.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateRequest.java
@@ -2,9 +2,11 @@ package com.animalleague.april.professor.api;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record ProfessorCreateRequest(
     @NotBlank(message = "교수명은 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "교수명은 100자 이하여야 합니다.")
     String professorName,
     @NotBlank(message = "성별은 비어 있을 수 없습니다.")
     @Pattern(regexp = "male|female", message = "성별은 male 또는 female 이어야 합니다.")

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateRequest.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateRequest.java
@@ -1,0 +1,20 @@
+package com.animalleague.april.professor.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ProfessorCreateRequest(
+    @NotBlank(message = "교수명은 비어 있을 수 없습니다.")
+    String professorName,
+    @NotBlank(message = "성별은 비어 있을 수 없습니다.")
+    @Pattern(regexp = "male|female", message = "성별은 male 또는 female 이어야 합니다.")
+    String gender,
+    @NotBlank(message = "성격 유형은 비어 있을 수 없습니다.")
+    @Pattern(
+        regexp = "gentle|tsundere|english_mix|shy",
+        message = "성격 유형은 gentle, tsundere, english_mix, shy 중 하나여야 합니다."
+    )
+    String personalityType,
+    String sourcePhotoUrl
+) {
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorCreateResponse.java
@@ -1,0 +1,4 @@
+package com.animalleague.april.professor.api;
+
+public record ProfessorCreateResponse(ProfessorResponse professor) {
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorDetailResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorDetailResponse.java
@@ -1,0 +1,10 @@
+package com.animalleague.april.professor.api;
+
+import java.util.List;
+
+public record ProfessorDetailResponse(
+    ProfessorResponse professor,
+    AffectionResponse affection,
+    List<CharacterAssetResponse> characterAssets
+) {
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorListResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorListResponse.java
@@ -1,0 +1,6 @@
+package com.animalleague.april.professor.api;
+
+import java.util.List;
+
+public record ProfessorListResponse(List<ProfessorResponse> professors) {
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/api/ProfessorResponse.java
@@ -1,0 +1,33 @@
+package com.animalleague.april.professor.api;
+
+import java.util.UUID;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.professor.domain.Professor;
+
+public record ProfessorResponse(
+    UUID id,
+    String professorName,
+    Gender gender,
+    PersonalityType personalityType,
+    String sourcePhotoUrl,
+    CharacterAssetStatus characterAssetStatus,
+    String representativeAssetUrl,
+    boolean isDefaultCharacterAssets
+) {
+
+    public static ProfessorResponse from(Professor professor) {
+        return new ProfessorResponse(
+            professor.getId(),
+            professor.getProfessorName(),
+            professor.getGender(),
+            professor.getPersonalityType(),
+            professor.getSourcePhotoUrl(),
+            professor.getCharacterAssetStatus(),
+            professor.getRepresentativeAssetUrl(),
+            professor.isDefaultCharacterAssets()
+        );
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/CurrentUserProvider.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/CurrentUserProvider.java
@@ -1,0 +1,8 @@
+package com.animalleague.april.professor.application;
+
+import java.util.UUID;
+
+public interface CurrentUserProvider {
+
+    UUID currentUserId();
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
@@ -50,7 +50,14 @@ public class ProfessorService {
         );
 
         Professor savedProfessor = professorRepository.save(professor);
-        affectionRepository.save(Affection.create(currentUserId, savedProfessor.getId(), 0));
+        professorRepository.flush();
+
+        UUID professorId = savedProfessor.getId();
+        if (professorId == null) {
+            throw new IllegalStateException("교수 ID 생성에 실패했습니다.");
+        }
+
+        affectionRepository.save(Affection.create(currentUserId, professorId, 0));
 
         return new ProfessorCreateResponse(ProfessorResponse.from(savedProfessor));
     }

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
@@ -1,0 +1,147 @@
+package com.animalleague.april.professor.application;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.professor.api.AffectionResponse;
+import com.animalleague.april.professor.api.ProfessorCreateRequest;
+import com.animalleague.april.professor.api.ProfessorCreateResponse;
+import com.animalleague.april.professor.api.ProfessorDetailResponse;
+import com.animalleague.april.professor.api.ProfessorListResponse;
+import com.animalleague.april.professor.api.ProfessorResponse;
+import com.animalleague.april.professor.domain.Affection;
+import com.animalleague.april.professor.domain.Professor;
+import com.animalleague.april.professor.infrastructure.AffectionRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorRepository;
+
+@Service
+public class ProfessorService {
+
+    private final ProfessorRepository professorRepository;
+    private final AffectionRepository affectionRepository;
+
+    public ProfessorService(
+        ProfessorRepository professorRepository,
+        AffectionRepository affectionRepository
+    ) {
+        this.professorRepository = professorRepository;
+        this.affectionRepository = affectionRepository;
+    }
+
+    @Transactional
+    public ProfessorCreateResponse createProfessor(ProfessorCreateRequest request) {
+        UUID currentUserId = resolveCurrentUserId();
+        Professor professor = Professor.create(
+            currentUserId,
+            request.professorName(),
+            Gender.fromValue(request.gender()),
+            PersonalityType.fromValue(request.personalityType()),
+            request.sourcePhotoUrl()
+        );
+
+        Professor savedProfessor = professorRepository.save(professor);
+        affectionRepository.save(Affection.create(currentUserId, savedProfessor.getId(), 0));
+
+        return new ProfessorCreateResponse(ProfessorResponse.from(savedProfessor));
+    }
+
+    @Transactional(readOnly = true)
+    public ProfessorListResponse listProfessors() {
+        UUID currentUserId = resolveCurrentUserId();
+        List<ProfessorResponse> professors = professorRepository.findAllByUserIdOrderByCreatedAtDesc(currentUserId)
+            .stream()
+            .map(ProfessorResponse::from)
+            .toList();
+        return new ProfessorListResponse(professors);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfessorDetailResponse getProfessorDetail(UUID professorId) {
+        UUID currentUserId = resolveCurrentUserId();
+        Professor professor = professorRepository.findByIdAndUserId(professorId, currentUserId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "교수를 찾을 수 없습니다."));
+
+        Affection affection = affectionRepository.findByProfessorIdAndUserId(professorId, currentUserId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "호감도 정보를 찾을 수 없습니다."));
+
+        return new ProfessorDetailResponse(
+            ProfessorResponse.from(professor),
+            AffectionResponse.from(affection),
+            List.of()
+        );
+    }
+
+    private UUID resolveCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+            || !authentication.isAuthenticated()
+            || authentication instanceof AnonymousAuthenticationToken) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+
+        UUID principalId = extractPrincipalId(authentication.getPrincipal());
+        if (principalId != null) {
+            return principalId;
+        }
+
+        return UUID.nameUUIDFromBytes(authentication.getName().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private UUID extractPrincipalId(Object principal) {
+        if (principal == null) {
+            return null;
+        }
+
+        if (principal instanceof UUID uuid) {
+            return uuid;
+        }
+
+        if (principal instanceof CharSequence sequence) {
+            try {
+                return UUID.fromString(sequence.toString());
+            } catch (IllegalArgumentException ignored) {
+                return null;
+            }
+        }
+
+        for (String methodName : List.of("id", "getId")) {
+            UUID resolved = invokeUuidAccessor(principal, methodName);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private UUID invokeUuidAccessor(Object principal, String methodName) {
+        try {
+            Method method = principal.getClass().getMethod(methodName);
+            Object result = method.invoke(principal);
+            if (result instanceof UUID uuid) {
+                return uuid;
+            }
+            if (result instanceof CharSequence sequence) {
+                return UUID.fromString(sequence.toString());
+            }
+            return null;
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException exception) {
+            return null;
+        }
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
@@ -1,15 +1,9 @@
 package com.animalleague.april.professor.application;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -32,13 +26,16 @@ public class ProfessorService {
 
     private final ProfessorRepository professorRepository;
     private final AffectionRepository affectionRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     public ProfessorService(
         ProfessorRepository professorRepository,
-        AffectionRepository affectionRepository
+        AffectionRepository affectionRepository,
+        CurrentUserProvider currentUserProvider
     ) {
         this.professorRepository = professorRepository;
         this.affectionRepository = affectionRepository;
+        this.currentUserProvider = currentUserProvider;
     }
 
     @Transactional
@@ -85,63 +82,10 @@ public class ProfessorService {
     }
 
     private UUID resolveCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null
-            || !authentication.isAuthenticated()
-            || authentication instanceof AnonymousAuthenticationToken) {
+        UUID currentUserId = currentUserProvider.currentUserId();
+        if (currentUserId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
         }
-
-        UUID principalId = extractPrincipalId(authentication.getPrincipal());
-        if (principalId != null) {
-            return principalId;
-        }
-
-        return UUID.nameUUIDFromBytes(authentication.getName().getBytes(StandardCharsets.UTF_8));
-    }
-
-    private UUID extractPrincipalId(Object principal) {
-        if (principal == null) {
-            return null;
-        }
-
-        if (principal instanceof UUID uuid) {
-            return uuid;
-        }
-
-        if (principal instanceof CharSequence sequence) {
-            try {
-                return UUID.fromString(sequence.toString());
-            } catch (IllegalArgumentException ignored) {
-                return null;
-            }
-        }
-
-        for (String methodName : List.of("id", "getId")) {
-            UUID resolved = invokeUuidAccessor(principal, methodName);
-            if (resolved != null) {
-                return resolved;
-            }
-        }
-
-        return null;
-    }
-
-    private UUID invokeUuidAccessor(Object principal, String methodName) {
-        try {
-            Method method = principal.getClass().getMethod(methodName);
-            Object result = method.invoke(principal);
-            if (result instanceof UUID uuid) {
-                return uuid;
-            }
-            if (result instanceof CharSequence sequence) {
-                return UUID.fromString(sequence.toString());
-            }
-            return null;
-        } catch (NoSuchMethodException ignored) {
-            return null;
-        } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException exception) {
-            return null;
-        }
+        return currentUserId;
     }
 }

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorService.java
@@ -50,14 +50,7 @@ public class ProfessorService {
         );
 
         Professor savedProfessor = professorRepository.save(professor);
-        professorRepository.flush();
-
-        UUID professorId = savedProfessor.getId();
-        if (professorId == null) {
-            throw new IllegalStateException("교수 ID 생성에 실패했습니다.");
-        }
-
-        affectionRepository.save(Affection.create(currentUserId, professorId, 0));
+        affectionRepository.save(Affection.create(currentUserId, savedProfessor.getId(), 0));
 
         return new ProfessorCreateResponse(ProfessorResponse.from(savedProfessor));
     }

--- a/Backend/src/main/java/com/animalleague/april/professor/application/SecurityContextCurrentUserProvider.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/SecurityContextCurrentUserProvider.java
@@ -1,0 +1,78 @@
+package com.animalleague.april.professor.application;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityContextCurrentUserProvider implements CurrentUserProvider {
+
+    @Override
+    public UUID currentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+            || !authentication.isAuthenticated()
+            || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        UUID principalId = extractPrincipalId(authentication.getPrincipal());
+        if (principalId != null) {
+            return principalId;
+        }
+
+        return UUID.nameUUIDFromBytes(authentication.getName().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private UUID extractPrincipalId(Object principal) {
+        if (principal == null) {
+            return null;
+        }
+
+        if (principal instanceof UUID uuid) {
+            return uuid;
+        }
+
+        if (principal instanceof CharSequence sequence) {
+            try {
+                return UUID.fromString(sequence.toString());
+            } catch (IllegalArgumentException ignored) {
+                return null;
+            }
+        }
+
+        for (String methodName : List.of("id", "getId")) {
+            UUID resolved = invokeUuidAccessor(principal, methodName);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private UUID invokeUuidAccessor(Object principal, String methodName) {
+        try {
+            Method method = principal.getClass().getMethod(methodName);
+            Object result = method.invoke(principal);
+            if (result instanceof UUID uuid) {
+                return uuid;
+            }
+            if (result instanceof CharSequence sequence) {
+                return UUID.fromString(sequence.toString());
+            }
+            return null;
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException exception) {
+            return null;
+        }
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/SecurityContextCurrentUserProvider.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/SecurityContextCurrentUserProvider.java
@@ -6,13 +6,21 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Supports UUID principal, UUID string principal, and public {@code id}/{@code getId()} accessors.
+ * When none are available, falls back to a deterministic UUID derived from {@link Authentication#getName()}.
+ */
 @Component
 public class SecurityContextCurrentUserProvider implements CurrentUserProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityContextCurrentUserProvider.class);
 
     @Override
     public UUID currentUserId() {
@@ -28,6 +36,10 @@ public class SecurityContextCurrentUserProvider implements CurrentUserProvider {
             return principalId;
         }
 
+        log.debug(
+            "principal에서 사용자 ID를 해석하지 못해 authentication.name 기반 UUID fallback을 사용합니다. principalType={}",
+            authentication.getPrincipal() == null ? "null" : authentication.getPrincipal().getClass().getName()
+        );
         return UUID.nameUUIDFromBytes(authentication.getName().getBytes(StandardCharsets.UTF_8));
     }
 
@@ -72,6 +84,12 @@ public class SecurityContextCurrentUserProvider implements CurrentUserProvider {
         } catch (NoSuchMethodException ignored) {
             return null;
         } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException exception) {
+            log.debug(
+                "principal accessor 호출에 실패했습니다. principalType={}, methodName={}",
+                principal.getClass().getName(),
+                methodName,
+                exception
+            );
             return null;
         }
     }

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
@@ -7,11 +7,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,10 +24,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
     uniqueConstraints = @UniqueConstraint(name = "uk_affections_user_professor", columnNames = {"user_id", "professor_id"})
 )
 @EntityListeners(AuditingEntityListener.class)
-public class Affection {
+public class Affection implements Persistable<UUID> {
 
     @Id
     private UUID id;
+
+    @Transient
+    private boolean isNew = true;
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
@@ -46,7 +52,8 @@ public class Affection {
     protected Affection() {
     }
 
-    private Affection(UUID userId, UUID professorId, int affectionScore) {
+    private Affection(UUID id, UUID userId, UUID professorId, int affectionScore) {
+        this.id = id;
         this.userId = userId;
         this.professorId = professorId;
         this.affectionScore = affectionScore;
@@ -65,18 +72,23 @@ public class Affection {
             throw new IllegalArgumentException("affectionScore는 0 이상 100 이하여야 합니다.");
         }
 
-        return new Affection(userId, professorId, affectionScore);
+        return new Affection(UUID.randomUUID(), userId, professorId, affectionScore);
     }
 
-    @PrePersist
-    void assignIdIfAbsent() {
-        if (id == null) {
-            id = UUID.randomUUID();
-        }
-    }
-
+    @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostPersist
+    @PostLoad
+    void markNotNew() {
+        this.isNew = false;
     }
 
     public UUID getUserId() {

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
@@ -6,9 +6,8 @@ import java.util.UUID;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
@@ -25,7 +24,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class Affection {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(name = "user_id", nullable = false)
@@ -68,6 +66,13 @@ public class Affection {
         }
 
         return new Affection(userId, professorId, affectionScore);
+    }
+
+    @PrePersist
+    void assignIdIfAbsent() {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     public UUID getId() {

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Affection.java
@@ -1,0 +1,96 @@
+package com.animalleague.april.professor.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+    name = "affections",
+    uniqueConstraints = @UniqueConstraint(name = "uk_affections_user_professor", columnNames = {"user_id", "professor_id"})
+)
+@EntityListeners(AuditingEntityListener.class)
+public class Affection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "professor_id", nullable = false)
+    private UUID professorId;
+
+    @Column(name = "affection_score", nullable = false)
+    private int affectionScore;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    protected Affection() {
+    }
+
+    private Affection(UUID userId, UUID professorId, int affectionScore) {
+        this.userId = userId;
+        this.professorId = professorId;
+        this.affectionScore = affectionScore;
+    }
+
+    public static Affection create(UUID userId, UUID professorId, int affectionScore) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 필수입니다.");
+        }
+
+        if (professorId == null) {
+            throw new IllegalArgumentException("professorId는 필수입니다.");
+        }
+
+        if (affectionScore < 0 || affectionScore > 100) {
+            throw new IllegalArgumentException("affectionScore는 0 이상 100 이하여야 합니다.");
+        }
+
+        return new Affection(userId, professorId, affectionScore);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public UUID getProfessorId() {
+        return professorId;
+    }
+
+    public int getAffectionScore() {
+        return affectionScore;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
@@ -9,10 +9,13 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,10 +26,13 @@ import com.animalleague.april.common.domain.PersonalityType;
 @Entity
 @Table(name = "professors")
 @EntityListeners(AuditingEntityListener.class)
-public class Professor {
+public class Professor implements Persistable<UUID> {
 
     @Id
     private UUID id;
+
+    @Transient
+    private boolean isNew = true;
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
@@ -67,6 +73,7 @@ public class Professor {
     }
 
     private Professor(
+        UUID id,
         UUID userId,
         String professorName,
         Gender gender,
@@ -76,6 +83,7 @@ public class Professor {
         String representativeAssetUrl,
         boolean isDefaultCharacterAssets
     ) {
+        this.id = id;
         this.userId = userId;
         this.professorName = professorName;
         this.gender = gender;
@@ -96,6 +104,7 @@ public class Professor {
         String normalizedSourcePhotoUrl = normalizeSourcePhotoUrl(sourcePhotoUrl);
         boolean hasSourcePhoto = normalizedSourcePhotoUrl != null;
         return new Professor(
+            UUID.randomUUID(),
             userId,
             professorName,
             gender,
@@ -116,15 +125,20 @@ public class Professor {
         return trimmed.isEmpty() ? null : trimmed;
     }
 
-    @PrePersist
-    void assignIdIfAbsent() {
-        if (id == null) {
-            id = UUID.randomUUID();
-        }
-    }
-
+    @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostPersist
+    @PostLoad
+    void markNotNew() {
+        this.isNew = false;
     }
 
     public UUID getUserId() {

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
@@ -1,0 +1,164 @@
+package com.animalleague.april.professor.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+
+@Entity
+@Table(name = "professors")
+@EntityListeners(AuditingEntityListener.class)
+public class Professor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "professor_name", nullable = false, length = 100)
+    private String professorName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "personality_type", nullable = false, length = 32)
+    private PersonalityType personalityType;
+
+    @Column(name = "source_photo_url")
+    private String sourcePhotoUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "character_asset_status", nullable = false, length = 16)
+    private CharacterAssetStatus characterAssetStatus;
+
+    @Column(name = "representative_asset_url")
+    private String representativeAssetUrl;
+
+    @Column(name = "is_default_character_assets", nullable = false)
+    private boolean isDefaultCharacterAssets;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    protected Professor() {
+    }
+
+    private Professor(
+        UUID userId,
+        String professorName,
+        Gender gender,
+        PersonalityType personalityType,
+        String sourcePhotoUrl,
+        CharacterAssetStatus characterAssetStatus,
+        String representativeAssetUrl,
+        boolean isDefaultCharacterAssets
+    ) {
+        this.userId = userId;
+        this.professorName = professorName;
+        this.gender = gender;
+        this.personalityType = personalityType;
+        this.sourcePhotoUrl = sourcePhotoUrl;
+        this.characterAssetStatus = characterAssetStatus;
+        this.representativeAssetUrl = representativeAssetUrl;
+        this.isDefaultCharacterAssets = isDefaultCharacterAssets;
+    }
+
+    public static Professor create(
+        UUID userId,
+        String professorName,
+        Gender gender,
+        PersonalityType personalityType,
+        String sourcePhotoUrl
+    ) {
+        String normalizedSourcePhotoUrl = normalizeSourcePhotoUrl(sourcePhotoUrl);
+        boolean hasSourcePhoto = normalizedSourcePhotoUrl != null;
+        return new Professor(
+            userId,
+            professorName,
+            gender,
+            personalityType,
+            normalizedSourcePhotoUrl,
+            hasSourcePhoto ? CharacterAssetStatus.PENDING : CharacterAssetStatus.READY,
+            null,
+            !hasSourcePhoto
+        );
+    }
+
+    private static String normalizeSourcePhotoUrl(String sourcePhotoUrl) {
+        if (sourcePhotoUrl == null) {
+            return null;
+        }
+
+        String trimmed = sourcePhotoUrl.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public String getProfessorName() {
+        return professorName;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    public PersonalityType getPersonalityType() {
+        return personalityType;
+    }
+
+    public String getSourcePhotoUrl() {
+        return sourcePhotoUrl;
+    }
+
+    public CharacterAssetStatus getCharacterAssetStatus() {
+        return characterAssetStatus;
+    }
+
+    public String getRepresentativeAssetUrl() {
+        return representativeAssetUrl;
+    }
+
+    public boolean isDefaultCharacterAssets() {
+        return isDefaultCharacterAssets;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/Professor.java
@@ -8,9 +8,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -27,7 +26,6 @@ import com.animalleague.april.common.domain.PersonalityType;
 public class Professor {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(name = "user_id", nullable = false)
@@ -116,6 +114,13 @@ public class Professor {
 
         String trimmed = sourcePhotoUrl.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    @PrePersist
+    void assignIdIfAbsent() {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     public UUID getId() {

--- a/Backend/src/main/java/com/animalleague/april/professor/infrastructure/AffectionRepository.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/infrastructure/AffectionRepository.java
@@ -1,0 +1,13 @@
+package com.animalleague.april.professor.infrastructure;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.animalleague.april.professor.domain.Affection;
+
+public interface AffectionRepository extends JpaRepository<Affection, UUID> {
+
+    Optional<Affection> findByProfessorIdAndUserId(UUID professorId, UUID userId);
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorRepository.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorRepository.java
@@ -1,0 +1,16 @@
+package com.animalleague.april.professor.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.animalleague.april.professor.domain.Professor;
+
+public interface ProfessorRepository extends JpaRepository<Professor, UUID> {
+
+    List<Professor> findAllByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    Optional<Professor> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/Backend/src/main/resources/db/migration/V2__create_professor_affection_tables.sql
+++ b/Backend/src/main/resources/db/migration/V2__create_professor_affection_tables.sql
@@ -1,0 +1,23 @@
+create table professors (
+    id uuid primary key,
+    user_id uuid not null,
+    professor_name varchar(100) not null,
+    gender varchar(16) not null,
+    personality_type varchar(32) not null,
+    source_photo_url text null,
+    character_asset_status varchar(16) not null,
+    representative_asset_url text null,
+    is_default_character_assets boolean not null,
+    created_at timestamptz not null,
+    updated_at timestamptz not null
+);
+
+create table affections (
+    id uuid primary key,
+    user_id uuid not null,
+    professor_id uuid not null references professors (id) on delete cascade,
+    affection_score integer not null check (affection_score between 0 and 100),
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    constraint uk_affections_user_professor unique (user_id, professor_id)
+);

--- a/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
@@ -177,4 +177,23 @@ class ProfessorContractTest extends ApiContractTest {
             .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
             .andExpect(jsonPath("$.violations[0].field").value("gender"));
     }
+
+    @Test
+    void tooLongProfessorNameReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "%s",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """.formatted("가".repeat(101)))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("professorName"));
+    }
 }

--- a/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
@@ -1,0 +1,180 @@
+package com.animalleague.april.contract.professor;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.common.infrastructure.GlobalExceptionHandler;
+import com.animalleague.april.contract.support.ApiContractTest;
+import com.animalleague.april.professor.api.AffectionResponse;
+import com.animalleague.april.professor.api.ProfessorController;
+import com.animalleague.april.professor.api.ProfessorCreateRequest;
+import com.animalleague.april.professor.api.ProfessorCreateResponse;
+import com.animalleague.april.professor.api.ProfessorDetailResponse;
+import com.animalleague.april.professor.api.ProfessorListResponse;
+import com.animalleague.april.professor.api.ProfessorResponse;
+import com.animalleague.april.professor.application.ProfessorService;
+
+@WebMvcTest(controllers = ProfessorController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class ProfessorContractTest extends ApiContractTest {
+
+    @MockBean
+    private ProfessorService professorService;
+
+    @Test
+    void createProfessorReturnsProfessorEnvelope() throws Exception {
+        ProfessorResponse professor = new ProfessorResponse(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "홍길동",
+            Gender.MALE,
+            PersonalityType.GENTLE,
+            null,
+            CharacterAssetStatus.READY,
+            null,
+            true
+        );
+        given(professorService.createProfessor(any(ProfessorCreateRequest.class)))
+            .willReturn(new ProfessorCreateResponse(professor));
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.id").value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
+            .andExpect(jsonPath("$.professor.gender").value("male"))
+            .andExpect(jsonPath("$.professor.personalityType").value("gentle"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
+    }
+
+    @Test
+    void createProfessorWithSourcePhotoReturnsPendingProfessorEnvelope() throws Exception {
+        ProfessorResponse professor = new ProfessorResponse(
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            "김교수",
+            Gender.FEMALE,
+            PersonalityType.SHY,
+            "https://cdn.example.com/source/prof_2.jpg",
+            CharacterAssetStatus.PENDING,
+            null,
+            false
+        );
+        given(professorService.createProfessor(any(ProfessorCreateRequest.class)))
+            .willReturn(new ProfessorCreateResponse(professor));
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "김교수",
+                          "gender": "female",
+                          "personalityType": "shy",
+                          "sourcePhotoUrl": "https://cdn.example.com/source/prof_2.jpg"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.id").value("22222222-2222-2222-2222-222222222222"))
+            .andExpect(jsonPath("$.professor.gender").value("female"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(false));
+    }
+
+    @Test
+    void listProfessorsReturnsProfessorArray() throws Exception {
+        ProfessorResponse professor = new ProfessorResponse(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "홍길동",
+            Gender.MALE,
+            PersonalityType.GENTLE,
+            null,
+            CharacterAssetStatus.READY,
+            null,
+            true
+        );
+        given(professorService.listProfessors())
+            .willReturn(new ProfessorListResponse(List.of(professor)));
+
+        mockMvc.perform(get("/api/professors"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professors[0].id").value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.professors[0].gender").value("male"))
+            .andExpect(jsonPath("$.professors[0].characterAssetStatus").value("ready"));
+    }
+
+    @Test
+    void getProfessorDetailReturnsAffectionAndCharacterAssets() throws Exception {
+        ProfessorResponse professor = new ProfessorResponse(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "홍길동",
+            Gender.MALE,
+            PersonalityType.GENTLE,
+            null,
+            CharacterAssetStatus.READY,
+            null,
+            true
+        );
+        given(professorService.getProfessorDetail(any(UUID.class)))
+                    .willReturn(
+                new ProfessorDetailResponse(
+                    professor,
+                    new AffectionResponse(UUID.fromString("11111111-1111-1111-1111-111111111111"), 0),
+                    List.of()
+                )
+            );
+
+        mockMvc.perform(get("/api/professors/11111111-1111-1111-1111-111111111111"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professor.id").value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.affection.professorId").value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.affection.affectionScore").value(0))
+            .andExpect(jsonPath("$.characterAssets").value(org.hamcrest.Matchers.hasSize(0)));
+    }
+
+    @Test
+    void invalidGenderReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "other",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("gender"));
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
@@ -109,6 +109,40 @@ class ProfessorContractTest extends ApiContractTest {
     }
 
     @Test
+    void createProfessorWithBlankSourcePhotoUrlReturnsReadyProfessorEnvelope() throws Exception {
+        ProfessorResponse professor = new ProfessorResponse(
+            UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            "김교수",
+            Gender.FEMALE,
+            PersonalityType.SHY,
+            null,
+            CharacterAssetStatus.READY,
+            null,
+            true
+        );
+        given(professorService.createProfessor(any(ProfessorCreateRequest.class)))
+            .willReturn(new ProfessorCreateResponse(professor));
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "김교수",
+                          "gender": "female",
+                          "personalityType": "shy",
+                          "sourcePhotoUrl": "   "
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.id").value("33333333-3333-3333-3333-333333333333"))
+            .andExpect(jsonPath("$.professor.sourcePhotoUrl").value(org.hamcrest.Matchers.nullValue()))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
+    }
+
+    @Test
     void listProfessorsReturnsProfessorArray() throws Exception {
         ProfessorResponse professor = new ProfessorResponse(
             UUID.fromString("11111111-1111-1111-1111-111111111111"),

--- a/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/professor/ProfessorContractTest.java
@@ -179,6 +179,82 @@ class ProfessorContractTest extends ApiContractTest {
     }
 
     @Test
+    void blankProfessorNameReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("professorName"));
+    }
+
+    @Test
+    void blankGenderReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("gender"));
+    }
+
+    @Test
+    void blankPersonalityTypeReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("personalityType"));
+    }
+
+    @Test
+    void invalidPersonalityTypeReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "invalid-type",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations[0].field").value("personalityType"));
+    }
+
+    @Test
     void tooLongProfessorNameReturns400() throws Exception {
         mockMvc.perform(
                 post("/api/professors")

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -26,6 +27,7 @@ import com.animalleague.april.integration.support.PostgresIntegrationTest;
 
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "spring.flyway.enabled=true")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 class AuthFlowIntegrationTest extends PostgresIntegrationTest {
 

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -3,22 +3,20 @@ package com.animalleague.april.integration.professor;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.server.ResponseStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +24,10 @@ import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.Gender;
 import com.animalleague.april.common.domain.PersonalityType;
 import com.animalleague.april.integration.support.PostgresIntegrationTest;
+import com.animalleague.april.professor.api.ProfessorCreateRequest;
+import com.animalleague.april.professor.api.ProfessorDetailResponse;
+import com.animalleague.april.professor.api.ProfessorListResponse;
+import com.animalleague.april.professor.application.ProfessorService;
 import com.animalleague.april.professor.domain.Affection;
 import com.animalleague.april.professor.domain.Professor;
 import com.animalleague.april.professor.infrastructure.AffectionRepository;
@@ -39,32 +41,21 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private ProfessorService professorService;
+
+    @Autowired
     private ProfessorRepository professorRepository;
 
     @Autowired
     private AffectionRepository affectionRepository;
 
     @Test
-    void createProfessorInitializesAffectionAtZero() throws Exception {
+    void createProfessorInitializesAffectionAtZero() {
         UUID userId = userIdFor("alice");
 
-        mockMvc.perform(
-                post("/api/professors")
-                    .with(authenticatedUser("alice"))
-                    .contentType("application/json")
-                    .content("""
-                        {
-                          "professorName": "홍길동",
-                          "gender": "male",
-                          "personalityType": "gentle",
-                          "sourcePhotoUrl": null
-                        }
-                        """)
-            )
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
-            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
-            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
+        runAs("alice", () -> professorService.createProfessor(
+            new ProfessorCreateRequest("홍길동", "male", "gentle", null)
+        ));
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getProfessorName()).isEqualTo("홍길동");
@@ -77,26 +68,17 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    void createProfessorWithSourcePhotoStartsInPendingState() throws Exception {
+    void createProfessorWithSourcePhotoStartsInPendingState() {
         UUID userId = userIdFor("alice");
 
-        mockMvc.perform(
-                post("/api/professors")
-                    .with(authenticatedUser("alice"))
-                    .contentType("application/json")
-                    .content("""
-                        {
-                          "professorName": "김교수",
-                          "gender": "female",
-                          "personalityType": "shy",
-                          "sourcePhotoUrl": "https://cdn.example.com/source/prof_2.jpg"
-                        }
-                        """)
+        runAs("alice", () -> professorService.createProfessor(
+            new ProfessorCreateRequest(
+                "김교수",
+                "female",
+                "shy",
+                "https://cdn.example.com/source/prof_2.jpg"
             )
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.professor.professorName").value("김교수"))
-            .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
-            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(false));
+        ));
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
@@ -105,93 +87,59 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    void professorListAndDetailAreScopedToAuthenticatedUser() throws Exception {
-        UUID aliceProfessorId = createProfessor(
-            "alice",
-            "알리스교수",
-            Gender.MALE,
-            PersonalityType.GENTLE,
-            null
-        );
-        UUID bobProfessorId = createProfessor(
-            "bob",
-            "밥교수",
-            Gender.FEMALE,
-            PersonalityType.SHY,
-            "https://cdn.example.com/source/bob.jpg"
-        );
-
-        mockMvc.perform(
-                get("/api/professors")
-                    .with(authenticatedUser("alice"))
+    void professorListAndDetailAreScopedToAuthenticatedUser() {
+        UUID aliceProfessorId = runAs("alice", () -> professorService.createProfessor(
+            new ProfessorCreateRequest("알리스교수", "male", "gentle", null)
+        ).professor().id());
+        UUID bobProfessorId = runAs("bob", () -> professorService.createProfessor(
+            new ProfessorCreateRequest(
+                "밥교수",
+                "female",
+                "shy",
+                "https://cdn.example.com/source/bob.jpg"
             )
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
+        ).professor().id());
 
-        mockMvc.perform(
-                get("/api/professors/{professorId}", aliceProfessorId)
-                    .with(authenticatedUser("alice"))
-            )
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professor.id").value(aliceProfessorId.toString()))
-            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessorId.toString()))
-            .andExpect(jsonPath("$.affection.affectionScore").value(0))
-            .andExpect(jsonPath("$.characterAssets", Matchers.hasSize(0)));
+        ProfessorListResponse aliceList = runAs("alice", professorService::listProfessors);
+        assertThat(aliceList.professors()).hasSize(1);
+        assertThat(aliceList.professors().getFirst().professorName()).isEqualTo("알리스교수");
 
-        mockMvc.perform(
-                get("/api/professors/{professorId}", bobProfessorId)
-                    .with(authenticatedUser("alice"))
-            )
-            .andExpect(status().isNotFound());
+        ProfessorDetailResponse aliceDetail = runAs("alice", () -> professorService.getProfessorDetail(aliceProfessorId));
+        assertThat(aliceDetail.professor().id()).isEqualTo(aliceProfessorId);
+        assertThat(aliceDetail.affection().professorId()).isEqualTo(aliceProfessorId);
+        assertThat(aliceDetail.affection().affectionScore()).isZero();
+        assertThat(aliceDetail.characterAssets()).isEmpty();
+
+        assertThatThrownBy(() -> runAs("alice", () -> professorService.getProfessorDetail(bobProfessorId)))
+            .isInstanceOf(ResponseStatusException.class)
+            .hasMessageContaining("404 NOT_FOUND");
     }
 
     @Test
     void unauthenticatedProfessorRequestReturns401() throws Exception {
+        SecurityContextHolder.clearContext();
+
         mockMvc.perform(get("/api/professors"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
-    }
-
-    private UUID createProfessor(
-        String username,
-        String professorName,
-        Gender gender,
-        PersonalityType personalityType,
-        String sourcePhotoUrl
-    ) throws Exception {
-        MvcResult result = mockMvc.perform(
-                post("/api/professors")
-                    .with(authenticatedUser(username))
-                    .contentType("application/json")
-                    .content("""
-                        {
-                          "professorName": "%s",
-                          "gender": "%s",
-                          "personalityType": "%s",
-                          "sourcePhotoUrl": %s
-                        }
-                        """.formatted(
-                        professorName,
-                        gender.value(),
-                        personalityType.value(),
-                        sourcePhotoUrl == null ? "null" : "\"%s\"".formatted(sourcePhotoUrl)
-                    ))
-            )
-            .andExpect(status().isCreated())
-            .andReturn();
-
-        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        return UUID.fromString(body.path("professor").path("id").asText());
     }
 
     private UUID userIdFor(String username) {
         return UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
     }
 
-    private RequestPostProcessor authenticatedUser(String username) {
-        return SecurityMockMvcRequestPostProcessors.authentication(
+    private <T> T runAs(String username, ThrowingSupplier<T> action) {
+        SecurityContextHolder.getContext().setAuthentication(
             UsernamePasswordAuthenticationToken.authenticated(username, null, List.of())
         );
+
+        try {
+            return action.get();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    private interface ThrowingSupplier<T> extends Supplier<T> {
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -28,6 +29,7 @@ import com.animalleague.april.professor.infrastructure.ProfessorRepository;
 
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "spring.flyway.enabled=true")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
     @Autowired

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -94,6 +94,35 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
+    void createProfessorWithWhitespaceSourcePhotoBehavesAsNoPhoto() throws Exception {
+        UUID userId = userIdFor("alice");
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": "   "
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated());
+
+        Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
+        assertThat(professor.getSourcePhotoUrl()).isNull();
+        assertThat(professor.getCharacterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(professor.isDefaultCharacterAssets()).isTrue();
+
+        Affection affection = affectionRepository.findByProfessorIdAndUserId(professor.getId(), userId)
+            .orElseThrow();
+        assertThat(affection.getAffectionScore()).isZero();
+    }
+
+    @Test
     void professorListAndDetailAreScopedToAuthenticatedUser() throws Exception {
         Professor aliceProfessor = seedProfessor("alice", "알리스교수", Gender.MALE, PersonalityType.GENTLE, null);
         Professor bobProfessor = seedProfessor(

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -3,18 +3,17 @@ package com.animalleague.april.integration.professor;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.server.ResponseStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,11 +21,6 @@ import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.Gender;
 import com.animalleague.april.common.domain.PersonalityType;
 import com.animalleague.april.integration.support.PostgresIntegrationTest;
-import com.animalleague.april.professor.application.CurrentUserProvider;
-import com.animalleague.april.professor.api.ProfessorCreateRequest;
-import com.animalleague.april.professor.api.ProfessorDetailResponse;
-import com.animalleague.april.professor.api.ProfessorListResponse;
-import com.animalleague.april.professor.application.ProfessorService;
 import com.animalleague.april.professor.domain.Affection;
 import com.animalleague.april.professor.domain.Professor;
 import com.animalleague.april.professor.infrastructure.AffectionRepository;
@@ -40,25 +34,32 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private ProfessorService professorService;
-
-    @MockBean
-    private CurrentUserProvider currentUserProvider;
-
-    @Autowired
     private ProfessorRepository professorRepository;
 
     @Autowired
     private AffectionRepository affectionRepository;
 
     @Test
-    void createProfessorInitializesAffectionAtZero() {
+    void createProfessorInitializesAffectionAtZero() throws Exception {
         UUID userId = userIdFor("alice");
-        given(currentUserProvider.currentUserId()).willReturn(userId);
 
-        professorService.createProfessor(
-            new ProfessorCreateRequest("홍길동", "male", "gentle", null)
-        );
+        mockMvc.perform(
+                post("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getProfessorName()).isEqualTo("홍길동");
@@ -71,18 +72,26 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    void createProfessorWithSourcePhotoStartsInPendingState() {
+    void createProfessorWithSourcePhotoStartsInPendingState() throws Exception {
         UUID userId = userIdFor("alice");
-        given(currentUserProvider.currentUserId()).willReturn(userId);
 
-        professorService.createProfessor(
-            new ProfessorCreateRequest(
-                "김교수",
-                "female",
-                "shy",
-                "https://cdn.example.com/source/prof_2.jpg"
+        mockMvc.perform(
+                post("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "김교수",
+                          "gender": "female",
+                          "personalityType": "shy",
+                          "sourcePhotoUrl": "https://cdn.example.com/source/prof_2.jpg"
+                        }
+                        """)
             )
-        );
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.professorName").value("김교수"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(false));
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
@@ -91,39 +100,39 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    void professorListAndDetailAreScopedToAuthenticatedUser() {
-        UUID aliceUserId = userIdFor("alice");
-        UUID bobUserId = userIdFor("bob");
+    void professorListAndDetailAreScopedToAuthenticatedUser() throws Exception {
+        Professor aliceProfessor = seedProfessor("alice", "알리스교수", Gender.MALE, PersonalityType.GENTLE, null);
+        Professor bobProfessor = seedProfessor(
+            "bob",
+            "밥교수",
+            Gender.FEMALE,
+            PersonalityType.SHY,
+            "https://cdn.example.com/source/bob.jpg"
+        );
 
-        given(currentUserProvider.currentUserId()).willReturn(aliceUserId);
-        UUID aliceProfessorId = professorService.createProfessor(
-            new ProfessorCreateRequest("알리스교수", "male", "gentle", null)
-        ).professor().id();
-
-        given(currentUserProvider.currentUserId()).willReturn(bobUserId);
-        UUID bobProfessorId = professorService.createProfessor(
-            new ProfessorCreateRequest(
-                "밥교수",
-                "female",
-                "shy",
-                "https://cdn.example.com/source/bob.jpg"
+        mockMvc.perform(
+                get("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
-        ).professor().id();
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
 
-        given(currentUserProvider.currentUserId()).willReturn(aliceUserId);
-        ProfessorListResponse aliceList = professorService.listProfessors();
-        assertThat(aliceList.professors()).hasSize(1);
-        assertThat(aliceList.professors().getFirst().professorName()).isEqualTo("알리스교수");
+        mockMvc.perform(
+                get("/api/professors/{professorId}", aliceProfessor.getId())
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.affection.affectionScore").value(0))
+            .andExpect(jsonPath("$.characterAssets", Matchers.hasSize(0)));
 
-        ProfessorDetailResponse aliceDetail = professorService.getProfessorDetail(aliceProfessorId);
-        assertThat(aliceDetail.professor().id()).isEqualTo(aliceProfessorId);
-        assertThat(aliceDetail.affection().professorId()).isEqualTo(aliceProfessorId);
-        assertThat(aliceDetail.affection().affectionScore()).isZero();
-        assertThat(aliceDetail.characterAssets()).isEmpty();
-
-        assertThatThrownBy(() -> professorService.getProfessorDetail(bobProfessorId))
-            .isInstanceOf(ResponseStatusException.class)
-            .hasMessageContaining("404 NOT_FOUND");
+        mockMvc.perform(
+                get("/api/professors/{professorId}", bobProfessor.getId())
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+            )
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -131,6 +140,22 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
         mockMvc.perform(get("/api/professors"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    private Professor seedProfessor(
+        String username,
+        String professorName,
+        Gender gender,
+        PersonalityType personalityType,
+        String sourcePhotoUrl
+    ) {
+        UUID userId = userIdFor(username);
+        Professor savedProfessor = professorRepository.save(
+            Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl)
+        );
+        professorRepository.flush();
+        affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
+        return savedProfessor;
     }
 
     private UUID userIdFor(String username) {

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,7 +43,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     void createProfessorInitializesAffectionAtZero() throws Exception {
         UUID userId = userIdFor("alice");
 
-        MvcResult createResult = mockMvc.perform(
+        mockMvc.perform(
                 post("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
                     .contentType("application/json")
@@ -57,21 +56,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
-            .andReturn();
-
-        System.err.printf(
-            "DIAG createProfessorInitializesAffectionAtZero status=%s body=%s%n",
-            createResult.getResponse().getStatus(),
-            createResult.getResponse().getContentAsString()
-        );
-
-        assertThat(createResult.getResponse().getStatus())
-            .withFailMessage(
-                "createProfessorInitializesAffectionAtZero status=%s body=%s",
-                createResult.getResponse().getStatus(),
-                createResult.getResponse().getContentAsString()
-            )
-            .isEqualTo(201);
+            .andExpect(status().isCreated());
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getProfessorName()).isEqualTo("홍길동");
@@ -87,7 +72,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     void createProfessorWithSourcePhotoStartsInPendingState() throws Exception {
         UUID userId = userIdFor("alice");
 
-        MvcResult createResult = mockMvc.perform(
+        mockMvc.perform(
                 post("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
                     .contentType("application/json")
@@ -100,21 +85,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
-            .andReturn();
-
-        System.err.printf(
-            "DIAG createProfessorWithSourcePhotoStartsInPendingState status=%s body=%s%n",
-            createResult.getResponse().getStatus(),
-            createResult.getResponse().getContentAsString()
-        );
-
-        assertThat(createResult.getResponse().getStatus())
-            .withFailMessage(
-                "createProfessorWithSourcePhotoStartsInPendingState status=%s body=%s",
-                createResult.getResponse().getStatus(),
-                createResult.getResponse().getContentAsString()
-            )
-            .isEqualTo(201);
+            .andExpect(status().isCreated());
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
@@ -133,49 +104,20 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             "https://cdn.example.com/source/bob.jpg"
         );
 
-        MvcResult listResult = mockMvc.perform(
+        mockMvc.perform(
                 get("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
-            .andReturn();
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
 
-        System.err.printf(
-            "DIAG professorList status=%s body=%s%n",
-            listResult.getResponse().getStatus(),
-            listResult.getResponse().getContentAsString()
-        );
-
-        assertThat(listResult.getResponse().getStatus())
-            .withFailMessage(
-                "professorList status=%s body=%s",
-                listResult.getResponse().getStatus(),
-                listResult.getResponse().getContentAsString()
-            )
-            .isEqualTo(200);
-        assertThat(listResult.getResponse().getContentAsString()).contains("알리스교수");
-
-        MvcResult detailResult = mockMvc.perform(
+        mockMvc.perform(
                 get("/api/professors/{professorId}", aliceProfessor.getId())
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
-            .andReturn();
-
-        System.err.printf(
-            "DIAG professorDetail status=%s body=%s%n",
-            detailResult.getResponse().getStatus(),
-            detailResult.getResponse().getContentAsString()
-        );
-
-        assertThat(detailResult.getResponse().getStatus())
-            .withFailMessage(
-                "professorDetail status=%s body=%s",
-                detailResult.getResponse().getStatus(),
-                detailResult.getResponse().getContentAsString()
-            )
-            .isEqualTo(200);
-        assertThat(detailResult.getResponse().getContentAsString())
-            .contains(aliceProfessor.getId().toString())
-            .contains("\"affectionScore\":0");
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.affection.affectionScore").value(0));
 
         mockMvc.perform(
                 get("/api/professors/{professorId}", bobProfessor.getId())
@@ -200,27 +142,10 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     ) {
         UUID userId = userIdFor(username);
         Professor professor = Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl);
-        try {
-            Professor savedProfessor = professorRepository.save(professor);
-            professorRepository.flush();
-            affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
-            return savedProfessor;
-        } catch (RuntimeException exception) {
-            System.err.printf(
-                "DIAG seedProfessor failed userId=%s professorName=%s gender=%s personalityType=%s sourcePhotoUrl=%s%n",
-                userId,
-                professorName,
-                gender,
-                personalityType,
-                sourcePhotoUrl
-            );
-            exception.printStackTrace(System.err);
-            throw new AssertionError(
-                "seedProfessor failed userId=%s, professorName=%s, gender=%s, personalityType=%s, sourcePhotoUrl=%s"
-                    .formatted(userId, professorName, gender, personalityType, sourcePhotoUrl),
-                exception
-            );
-        }
+        Professor savedProfessor = professorRepository.save(professor);
+        professorRepository.flush();
+        affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
+        return savedProfessor;
     }
 
     private UUID userIdFor(String username) {

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -1,21 +1,19 @@
 package com.animalleague.april.integration.professor;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -24,6 +22,7 @@ import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.Gender;
 import com.animalleague.april.common.domain.PersonalityType;
 import com.animalleague.april.integration.support.PostgresIntegrationTest;
+import com.animalleague.april.professor.application.CurrentUserProvider;
 import com.animalleague.april.professor.api.ProfessorCreateRequest;
 import com.animalleague.april.professor.api.ProfessorDetailResponse;
 import com.animalleague.april.professor.api.ProfessorListResponse;
@@ -43,6 +42,9 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     @Autowired
     private ProfessorService professorService;
 
+    @MockBean
+    private CurrentUserProvider currentUserProvider;
+
     @Autowired
     private ProfessorRepository professorRepository;
 
@@ -52,10 +54,11 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     @Test
     void createProfessorInitializesAffectionAtZero() {
         UUID userId = userIdFor("alice");
+        given(currentUserProvider.currentUserId()).willReturn(userId);
 
-        runAs("alice", () -> professorService.createProfessor(
+        professorService.createProfessor(
             new ProfessorCreateRequest("홍길동", "male", "gentle", null)
-        ));
+        );
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getProfessorName()).isEqualTo("홍길동");
@@ -70,15 +73,16 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     @Test
     void createProfessorWithSourcePhotoStartsInPendingState() {
         UUID userId = userIdFor("alice");
+        given(currentUserProvider.currentUserId()).willReturn(userId);
 
-        runAs("alice", () -> professorService.createProfessor(
+        professorService.createProfessor(
             new ProfessorCreateRequest(
                 "김교수",
                 "female",
                 "shy",
                 "https://cdn.example.com/source/prof_2.jpg"
             )
-        ));
+        );
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
@@ -88,37 +92,42 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
     @Test
     void professorListAndDetailAreScopedToAuthenticatedUser() {
-        UUID aliceProfessorId = runAs("alice", () -> professorService.createProfessor(
+        UUID aliceUserId = userIdFor("alice");
+        UUID bobUserId = userIdFor("bob");
+
+        given(currentUserProvider.currentUserId()).willReturn(aliceUserId);
+        UUID aliceProfessorId = professorService.createProfessor(
             new ProfessorCreateRequest("알리스교수", "male", "gentle", null)
-        ).professor().id());
-        UUID bobProfessorId = runAs("bob", () -> professorService.createProfessor(
+        ).professor().id();
+
+        given(currentUserProvider.currentUserId()).willReturn(bobUserId);
+        UUID bobProfessorId = professorService.createProfessor(
             new ProfessorCreateRequest(
                 "밥교수",
                 "female",
                 "shy",
                 "https://cdn.example.com/source/bob.jpg"
             )
-        ).professor().id());
+        ).professor().id();
 
-        ProfessorListResponse aliceList = runAs("alice", professorService::listProfessors);
+        given(currentUserProvider.currentUserId()).willReturn(aliceUserId);
+        ProfessorListResponse aliceList = professorService.listProfessors();
         assertThat(aliceList.professors()).hasSize(1);
         assertThat(aliceList.professors().getFirst().professorName()).isEqualTo("알리스교수");
 
-        ProfessorDetailResponse aliceDetail = runAs("alice", () -> professorService.getProfessorDetail(aliceProfessorId));
+        ProfessorDetailResponse aliceDetail = professorService.getProfessorDetail(aliceProfessorId);
         assertThat(aliceDetail.professor().id()).isEqualTo(aliceProfessorId);
         assertThat(aliceDetail.affection().professorId()).isEqualTo(aliceProfessorId);
         assertThat(aliceDetail.affection().affectionScore()).isZero();
         assertThat(aliceDetail.characterAssets()).isEmpty();
 
-        assertThatThrownBy(() -> runAs("alice", () -> professorService.getProfessorDetail(bobProfessorId)))
+        assertThatThrownBy(() -> professorService.getProfessorDetail(bobProfessorId))
             .isInstanceOf(ResponseStatusException.class)
             .hasMessageContaining("404 NOT_FOUND");
     }
 
     @Test
     void unauthenticatedProfessorRequestReturns401() throws Exception {
-        SecurityContextHolder.clearContext();
-
         mockMvc.perform(get("/api/professors"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
@@ -126,20 +135,5 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
     private UUID userIdFor(String username) {
         return UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private <T> T runAs(String username, ThrowingSupplier<T> action) {
-        SecurityContextHolder.getContext().setAuthentication(
-            UsernamePasswordAuthenticationToken.authenticated(username, null, List.of())
-        );
-
-        try {
-            return action.get();
-        } finally {
-            SecurityContextHolder.clearContext();
-        }
-    }
-
-    private interface ThrowingSupplier<T> extends Supplier<T> {
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -138,7 +138,10 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
+            .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"))
+            .andExpect(jsonPath("$.professors[*].id", Matchers.not(Matchers.hasItem(bobProfessor.getId().toString()))))
+            .andExpect(jsonPath("$.professors[*].professorName", Matchers.not(Matchers.hasItem("밥교수"))));
 
         mockMvc.perform(
                 get("/api/professors/{professorId}", aliceProfessor.getId())

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -59,6 +59,12 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             )
             .andReturn();
 
+        System.err.printf(
+            "DIAG createProfessorInitializesAffectionAtZero status=%s body=%s%n",
+            createResult.getResponse().getStatus(),
+            createResult.getResponse().getContentAsString()
+        );
+
         assertThat(createResult.getResponse().getStatus())
             .withFailMessage(
                 "createProfessorInitializesAffectionAtZero status=%s body=%s",
@@ -96,6 +102,12 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             )
             .andReturn();
 
+        System.err.printf(
+            "DIAG createProfessorWithSourcePhotoStartsInPendingState status=%s body=%s%n",
+            createResult.getResponse().getStatus(),
+            createResult.getResponse().getContentAsString()
+        );
+
         assertThat(createResult.getResponse().getStatus())
             .withFailMessage(
                 "createProfessorWithSourcePhotoStartsInPendingState status=%s body=%s",
@@ -127,6 +139,12 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             )
             .andReturn();
 
+        System.err.printf(
+            "DIAG professorList status=%s body=%s%n",
+            listResult.getResponse().getStatus(),
+            listResult.getResponse().getContentAsString()
+        );
+
         assertThat(listResult.getResponse().getStatus())
             .withFailMessage(
                 "professorList status=%s body=%s",
@@ -141,6 +159,12 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
             .andReturn();
+
+        System.err.printf(
+            "DIAG professorDetail status=%s body=%s%n",
+            detailResult.getResponse().getStatus(),
+            detailResult.getResponse().getContentAsString()
+        );
 
         assertThat(detailResult.getResponse().getStatus())
             .withFailMessage(
@@ -182,6 +206,15 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
             return savedProfessor;
         } catch (RuntimeException exception) {
+            System.err.printf(
+                "DIAG seedProfessor failed userId=%s professorName=%s gender=%s personalityType=%s sourcePhotoUrl=%s%n",
+                userId,
+                professorName,
+                gender,
+                personalityType,
+                sourcePhotoUrl
+            );
+            exception.printStackTrace(System.err);
             throw new AssertionError(
                 "seedProfessor failed userId=%s, professorName=%s, gender=%s, personalityType=%s, sourcePhotoUrl=%s"
                     .formatted(userId, professorName, gender, personalityType, sourcePhotoUrl),

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -1,0 +1,163 @@
+package com.animalleague.april.integration.professor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.integration.support.PostgresIntegrationTest;
+import com.animalleague.april.professor.domain.Affection;
+import com.animalleague.april.professor.domain.Professor;
+import com.animalleague.april.professor.infrastructure.AffectionRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorRepository;
+
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "spring.flyway.enabled=true")
+class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProfessorRepository professorRepository;
+
+    @Autowired
+    private AffectionRepository affectionRepository;
+
+    @Test
+    void createProfessorInitializesAffectionAtZero() throws Exception {
+        UUID userId = userIdFor("alice");
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
+
+        Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
+        assertThat(professor.getProfessorName()).isEqualTo("홍길동");
+        assertThat(professor.getCharacterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(professor.isDefaultCharacterAssets()).isTrue();
+
+        Affection affection = affectionRepository.findByProfessorIdAndUserId(professor.getId(), userId)
+            .orElseThrow();
+        assertThat(affection.getAffectionScore()).isZero();
+    }
+
+    @Test
+    void createProfessorWithSourcePhotoStartsInPendingState() throws Exception {
+        UUID userId = userIdFor("alice");
+
+        mockMvc.perform(
+                post("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "김교수",
+                          "gender": "female",
+                          "personalityType": "shy",
+                          "sourcePhotoUrl": "https://cdn.example.com/source/prof_2.jpg"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.professor.professorName").value("김교수"))
+            .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
+            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(false));
+
+        Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
+        assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
+        assertThat(professor.getCharacterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
+        assertThat(professor.isDefaultCharacterAssets()).isFalse();
+    }
+
+    @Test
+    void professorListAndDetailAreScopedToAuthenticatedUser() throws Exception {
+        Professor aliceProfessor = seedProfessor("alice", "알리스교수", Gender.MALE, PersonalityType.GENTLE, null);
+        Professor bobProfessor = seedProfessor(
+            "bob",
+            "밥교수",
+            Gender.FEMALE,
+            PersonalityType.SHY,
+            "https://cdn.example.com/source/bob.jpg"
+        );
+
+        mockMvc.perform(
+                get("/api/professors")
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
+            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
+
+        mockMvc.perform(
+                get("/api/professors/{professorId}", aliceProfessor.getId())
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.affection.affectionScore").value(0))
+            .andExpect(jsonPath("$.characterAssets", Matchers.hasSize(0)));
+
+        mockMvc.perform(
+                get("/api/professors/{professorId}", bobProfessor.getId())
+                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+            )
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void unauthenticatedProfessorRequestReturns401() throws Exception {
+        mockMvc.perform(get("/api/professors"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    private Professor seedProfessor(
+        String username,
+        String professorName,
+        Gender gender,
+        PersonalityType personalityType,
+        String sourcePhotoUrl
+    ) {
+        UUID userId = userIdFor(username);
+        Professor savedProfessor = professorRepository.save(
+            Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl)
+        );
+        affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
+        return savedProfessor;
+    }
+
+    private UUID userIdFor(String username) {
+        return UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -165,6 +165,24 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
+    @Test
+    void unauthenticatedProfessorCreationRequestReturns401() throws Exception {
+        mockMvc.perform(
+                post("/api/professors")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "홍길동",
+                          "gender": "male",
+                          "personalityType": "gentle",
+                          "sourcePhotoUrl": null
+                        }
+                        """)
+            )
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
     private Professor seedProfessor(
         String username,
         String professorName,

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -56,6 +57,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
+            .andDo(print())
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
             .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
@@ -88,6 +90,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
+            .andDo(print())
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.professor.professorName").value("김교수"))
             .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
@@ -114,6 +117,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                 get("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
+            .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
@@ -122,6 +126,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                 get("/api/professors/{professorId}", aliceProfessor.getId())
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
+            .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
             .andExpect(jsonPath("$.affection.professorId").value(aliceProfessor.getId().toString()))
@@ -150,12 +155,19 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
         String sourcePhotoUrl
     ) {
         UUID userId = userIdFor(username);
-        Professor savedProfessor = professorRepository.save(
-            Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl)
-        );
-        professorRepository.flush();
-        affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
-        return savedProfessor;
+        Professor professor = Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl);
+        try {
+            Professor savedProfessor = professorRepository.save(professor);
+            professorRepository.flush();
+            affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
+            return savedProfessor;
+        } catch (RuntimeException exception) {
+            throw new AssertionError(
+                "seedProfessor failed userId=%s, professorName=%s, gender=%s, personalityType=%s, sourcePhotoUrl=%s"
+                    .formatted(userId, professorName, gender, personalityType, sourcePhotoUrl),
+                exception
+            );
+        }
     }
 
     private UUID userIdFor(String username) {

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -1,15 +1,20 @@
 package com.animalleague.april.integration.professor;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,7 +50,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
         mockMvc.perform(
                 post("/api/professors")
-                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .with(authenticatedUser("alice"))
                     .contentType("application/json")
                     .content("""
                         {
@@ -77,7 +82,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
         mockMvc.perform(
                 post("/api/professors")
-                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .with(authenticatedUser("alice"))
                     .contentType("application/json")
                     .content("""
                         {
@@ -101,8 +106,14 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
     @Test
     void professorListAndDetailAreScopedToAuthenticatedUser() throws Exception {
-        Professor aliceProfessor = seedProfessor("alice", "알리스교수", Gender.MALE, PersonalityType.GENTLE, null);
-        Professor bobProfessor = seedProfessor(
+        UUID aliceProfessorId = createProfessor(
+            "alice",
+            "알리스교수",
+            Gender.MALE,
+            PersonalityType.GENTLE,
+            null
+        );
+        UUID bobProfessorId = createProfessor(
             "bob",
             "밥교수",
             Gender.FEMALE,
@@ -112,25 +123,25 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
 
         mockMvc.perform(
                 get("/api/professors")
-                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                    .with(authenticatedUser("alice"))
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
 
         mockMvc.perform(
-                get("/api/professors/{professorId}", aliceProfessor.getId())
-                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                get("/api/professors/{professorId}", aliceProfessorId)
+                    .with(authenticatedUser("alice"))
             )
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
-            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessor.getId().toString()))
+            .andExpect(jsonPath("$.professor.id").value(aliceProfessorId.toString()))
+            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessorId.toString()))
             .andExpect(jsonPath("$.affection.affectionScore").value(0))
             .andExpect(jsonPath("$.characterAssets", Matchers.hasSize(0)));
 
         mockMvc.perform(
-                get("/api/professors/{professorId}", bobProfessor.getId())
-                    .with(SecurityMockMvcRequestPostProcessors.user("alice"))
+                get("/api/professors/{professorId}", bobProfessorId)
+                    .with(authenticatedUser("alice"))
             )
             .andExpect(status().isNotFound());
     }
@@ -142,22 +153,45 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
-    private Professor seedProfessor(
+    private UUID createProfessor(
         String username,
         String professorName,
         Gender gender,
         PersonalityType personalityType,
         String sourcePhotoUrl
-    ) {
-        UUID userId = userIdFor(username);
-        Professor savedProfessor = professorRepository.save(
-            Professor.create(userId, professorName, gender, personalityType, sourcePhotoUrl)
-        );
-        affectionRepository.save(Affection.create(userId, savedProfessor.getId(), 0));
-        return savedProfessor;
+    ) throws Exception {
+        MvcResult result = mockMvc.perform(
+                post("/api/professors")
+                    .with(authenticatedUser(username))
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "professorName": "%s",
+                          "gender": "%s",
+                          "personalityType": "%s",
+                          "sourcePhotoUrl": %s
+                        }
+                        """.formatted(
+                        professorName,
+                        gender.value(),
+                        personalityType.value(),
+                        sourcePhotoUrl == null ? "null" : "\"%s\"".formatted(sourcePhotoUrl)
+                    ))
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        return UUID.fromString(body.path("professor").path("id").asText());
     }
 
     private UUID userIdFor(String username) {
         return UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private RequestPostProcessor authenticatedUser(String username) {
+        return SecurityMockMvcRequestPostProcessors.authentication(
+            UsernamePasswordAuthenticationToken.authenticated(username, null, List.of())
+        );
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorRegistrationIntegrationTest.java
@@ -10,11 +10,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,7 +44,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     void createProfessorInitializesAffectionAtZero() throws Exception {
         UUID userId = userIdFor("alice");
 
-        mockMvc.perform(
+        MvcResult createResult = mockMvc.perform(
                 post("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
                     .contentType("application/json")
@@ -57,11 +57,15 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.professor.professorName").value("홍길동"))
-            .andExpect(jsonPath("$.professor.characterAssetStatus").value("ready"))
-            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(true));
+            .andReturn();
+
+        assertThat(createResult.getResponse().getStatus())
+            .withFailMessage(
+                "createProfessorInitializesAffectionAtZero status=%s body=%s",
+                createResult.getResponse().getStatus(),
+                createResult.getResponse().getContentAsString()
+            )
+            .isEqualTo(201);
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getProfessorName()).isEqualTo("홍길동");
@@ -77,7 +81,7 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
     void createProfessorWithSourcePhotoStartsInPendingState() throws Exception {
         UUID userId = userIdFor("alice");
 
-        mockMvc.perform(
+        MvcResult createResult = mockMvc.perform(
                 post("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
                     .contentType("application/json")
@@ -90,11 +94,15 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
                         }
                         """)
             )
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.professor.professorName").value("김교수"))
-            .andExpect(jsonPath("$.professor.characterAssetStatus").value("pending"))
-            .andExpect(jsonPath("$.professor.isDefaultCharacterAssets").value(false));
+            .andReturn();
+
+        assertThat(createResult.getResponse().getStatus())
+            .withFailMessage(
+                "createProfessorWithSourcePhotoStartsInPendingState status=%s body=%s",
+                createResult.getResponse().getStatus(),
+                createResult.getResponse().getContentAsString()
+            )
+            .isEqualTo(201);
 
         Professor professor = professorRepository.findAllByUserIdOrderByCreatedAtDesc(userId).getFirst();
         assertThat(professor.getSourcePhotoUrl()).isEqualTo("https://cdn.example.com/source/prof_2.jpg");
@@ -113,25 +121,37 @@ class ProfessorRegistrationIntegrationTest extends PostgresIntegrationTest {
             "https://cdn.example.com/source/bob.jpg"
         );
 
-        mockMvc.perform(
+        MvcResult listResult = mockMvc.perform(
                 get("/api/professors")
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professors", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.professors[0].professorName").value("알리스교수"));
+            .andReturn();
 
-        mockMvc.perform(
+        assertThat(listResult.getResponse().getStatus())
+            .withFailMessage(
+                "professorList status=%s body=%s",
+                listResult.getResponse().getStatus(),
+                listResult.getResponse().getContentAsString()
+            )
+            .isEqualTo(200);
+        assertThat(listResult.getResponse().getContentAsString()).contains("알리스교수");
+
+        MvcResult detailResult = mockMvc.perform(
                 get("/api/professors/{professorId}", aliceProfessor.getId())
                     .with(SecurityMockMvcRequestPostProcessors.user("alice"))
             )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.professor.id").value(aliceProfessor.getId().toString()))
-            .andExpect(jsonPath("$.affection.professorId").value(aliceProfessor.getId().toString()))
-            .andExpect(jsonPath("$.affection.affectionScore").value(0))
-            .andExpect(jsonPath("$.characterAssets", Matchers.hasSize(0)));
+            .andReturn();
+
+        assertThat(detailResult.getResponse().getStatus())
+            .withFailMessage(
+                "professorDetail status=%s body=%s",
+                detailResult.getResponse().getStatus(),
+                detailResult.getResponse().getContentAsString()
+            )
+            .isEqualTo(200);
+        assertThat(detailResult.getResponse().getContentAsString())
+            .contains(aliceProfessor.getId().toString())
+            .contains("\"affectionScore\":0");
 
         mockMvc.perform(
                 get("/api/professors/{professorId}", bobProfessor.getId())

--- a/Backend/src/test/java/com/animalleague/april/integration/support/PostgresIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/support/PostgresIntegrationTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -17,6 +18,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest
 @ActiveProfiles("test")
 @Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class PostgresIntegrationTest {

--- a/Backend/src/test/java/com/animalleague/april/integration/support/PostgresIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/support/PostgresIntegrationTest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -18,7 +17,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest
 @ActiveProfiles("test")
 @Testcontainers(disabledWithoutDocker = true)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class PostgresIntegrationTest {

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
@@ -4,6 +4,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,5 +89,26 @@ class AffectionInitializationUnitTest {
         assertThatThrownBy(() -> Affection.create(UUID.randomUUID(), UUID.randomUUID(), -1))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("affectionScore는 0 이상 100 이하여야 합니다.");
+    }
+
+    @Test
+    void listProfessorsThrowsUnauthorizedForUnauthenticatedUser() {
+        ProfessorRepository professorRepository = mock(ProfessorRepository.class);
+        AffectionRepository affectionRepository = mock(AffectionRepository.class);
+        CurrentUserProvider currentUserProvider = mock(CurrentUserProvider.class);
+        ProfessorService professorService = new ProfessorService(
+            professorRepository,
+            affectionRepository,
+            currentUserProvider
+        );
+        given(currentUserProvider.currentUserId()).willReturn(null);
+
+        assertThatThrownBy(professorService::listProfessors)
+            .isInstanceOf(ResponseStatusException.class)
+            .satisfies(exception -> {
+                ResponseStatusException responseStatusException = (ResponseStatusException) exception;
+                assertThat(responseStatusException.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+                assertThat(responseStatusException.getReason()).isEqualTo("인증이 필요합니다.");
+            });
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
@@ -1,12 +1,9 @@
 package com.animalleague.april.unit.professor;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,6 +17,7 @@ import com.animalleague.april.common.domain.Gender;
 import com.animalleague.april.common.domain.PersonalityType;
 import com.animalleague.april.professor.api.ProfessorCreateRequest;
 import com.animalleague.april.professor.api.ProfessorCreateResponse;
+import com.animalleague.april.professor.application.CurrentUserProvider;
 import com.animalleague.april.professor.application.ProfessorService;
 import com.animalleague.april.professor.domain.Affection;
 import com.animalleague.april.professor.domain.Professor;
@@ -32,14 +30,17 @@ class AffectionInitializationUnitTest {
     void createProfessorSavesProfessorAndAffectionForAuthenticatedUser() {
         ProfessorRepository professorRepository = mock(ProfessorRepository.class);
         AffectionRepository affectionRepository = mock(AffectionRepository.class);
-        ProfessorService professorService = new ProfessorService(professorRepository, affectionRepository);
+        CurrentUserProvider currentUserProvider = mock(CurrentUserProvider.class);
+        ProfessorService professorService = new ProfessorService(
+            professorRepository,
+            affectionRepository,
+            currentUserProvider
+        );
 
         String username = "worker-2";
         UUID expectedUserId = UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
         UUID persistedProfessorId = UUID.fromString("33333333-3333-3333-3333-333333333333");
-        SecurityContextHolder.getContext().setAuthentication(
-            UsernamePasswordAuthenticationToken.authenticated(username, null, List.of())
-        );
+        given(currentUserProvider.currentUserId()).willReturn(expectedUserId);
 
         Professor persistedProfessor = mock(Professor.class);
         given(persistedProfessor.getId()).willReturn(persistedProfessorId);
@@ -53,36 +54,32 @@ class AffectionInitializationUnitTest {
         given(professorRepository.save(any(Professor.class))).willReturn(persistedProfessor);
         given(affectionRepository.save(any(Affection.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        try {
-            ProfessorCreateResponse response = professorService.createProfessor(
-                new ProfessorCreateRequest(
-                    "홍길동",
-                    "male",
-                    "gentle",
-                    "https://cdn.example.com/source/prof_3.jpg"
-                )
-            );
+        ProfessorCreateResponse response = professorService.createProfessor(
+            new ProfessorCreateRequest(
+                "홍길동",
+                "male",
+                "gentle",
+                "https://cdn.example.com/source/prof_3.jpg"
+            )
+        );
 
-            assertThat(response.professor().characterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
-            assertThat(response.professor().isDefaultCharacterAssets()).isFalse();
+        assertThat(response.professor().characterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
+        assertThat(response.professor().isDefaultCharacterAssets()).isFalse();
 
-            verify(professorRepository).save(
-                org.mockito.ArgumentMatchers.argThat(professor ->
-                    expectedUserId.equals(professor.getUserId())
-                        && professor.getCharacterAssetStatus() == CharacterAssetStatus.PENDING
-                        && !professor.isDefaultCharacterAssets()
-                )
-            );
-            verify(affectionRepository).save(
-                org.mockito.ArgumentMatchers.argThat(affection ->
-                    expectedUserId.equals(affection.getUserId())
-                        && persistedProfessorId.equals(affection.getProfessorId())
-                        && affection.getAffectionScore() == 0
-                )
-            );
-        } finally {
-            SecurityContextHolder.clearContext();
-        }
+        verify(professorRepository).save(
+            org.mockito.ArgumentMatchers.argThat(professor ->
+                expectedUserId.equals(professor.getUserId())
+                    && professor.getCharacterAssetStatus() == CharacterAssetStatus.PENDING
+                    && !professor.isDefaultCharacterAssets()
+            )
+        );
+        verify(affectionRepository).save(
+            org.mockito.ArgumentMatchers.argThat(affection ->
+                expectedUserId.equals(affection.getUserId())
+                    && persistedProfessorId.equals(affection.getProfessorId())
+                    && affection.getAffectionScore() == 0
+            )
+        );
     }
 
     @Test

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/AffectionInitializationUnitTest.java
@@ -1,0 +1,94 @@
+package com.animalleague.april.unit.professor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.Gender;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.professor.api.ProfessorCreateRequest;
+import com.animalleague.april.professor.api.ProfessorCreateResponse;
+import com.animalleague.april.professor.application.ProfessorService;
+import com.animalleague.april.professor.domain.Affection;
+import com.animalleague.april.professor.domain.Professor;
+import com.animalleague.april.professor.infrastructure.AffectionRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorRepository;
+
+class AffectionInitializationUnitTest {
+
+    @Test
+    void createProfessorSavesProfessorAndAffectionForAuthenticatedUser() {
+        ProfessorRepository professorRepository = mock(ProfessorRepository.class);
+        AffectionRepository affectionRepository = mock(AffectionRepository.class);
+        ProfessorService professorService = new ProfessorService(professorRepository, affectionRepository);
+
+        String username = "worker-2";
+        UUID expectedUserId = UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8));
+        UUID persistedProfessorId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+        SecurityContextHolder.getContext().setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(username, null, List.of())
+        );
+
+        Professor persistedProfessor = mock(Professor.class);
+        given(persistedProfessor.getId()).willReturn(persistedProfessorId);
+        given(persistedProfessor.getProfessorName()).willReturn("홍길동");
+        given(persistedProfessor.getGender()).willReturn(Gender.MALE);
+        given(persistedProfessor.getPersonalityType()).willReturn(PersonalityType.GENTLE);
+        given(persistedProfessor.getSourcePhotoUrl()).willReturn("https://cdn.example.com/source/prof_3.jpg");
+        given(persistedProfessor.getCharacterAssetStatus()).willReturn(CharacterAssetStatus.PENDING);
+        given(persistedProfessor.getRepresentativeAssetUrl()).willReturn(null);
+        given(persistedProfessor.isDefaultCharacterAssets()).willReturn(false);
+        given(professorRepository.save(any(Professor.class))).willReturn(persistedProfessor);
+        given(affectionRepository.save(any(Affection.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        try {
+            ProfessorCreateResponse response = professorService.createProfessor(
+                new ProfessorCreateRequest(
+                    "홍길동",
+                    "male",
+                    "gentle",
+                    "https://cdn.example.com/source/prof_3.jpg"
+                )
+            );
+
+            assertThat(response.professor().characterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
+            assertThat(response.professor().isDefaultCharacterAssets()).isFalse();
+
+            verify(professorRepository).save(
+                org.mockito.ArgumentMatchers.argThat(professor ->
+                    expectedUserId.equals(professor.getUserId())
+                        && professor.getCharacterAssetStatus() == CharacterAssetStatus.PENDING
+                        && !professor.isDefaultCharacterAssets()
+                )
+            );
+            verify(affectionRepository).save(
+                org.mockito.ArgumentMatchers.argThat(affection ->
+                    expectedUserId.equals(affection.getUserId())
+                        && persistedProfessorId.equals(affection.getProfessorId())
+                        && affection.getAffectionScore() == 0
+                )
+            );
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test
+    void affectionRejectsNegativeScore() {
+        assertThatThrownBy(() -> Affection.create(UUID.randomUUID(), UUID.randomUUID(), -1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("affectionScore는 0 이상 100 이하여야 합니다.");
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/SecurityContextCurrentUserProviderUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/SecurityContextCurrentUserProviderUnitTest.java
@@ -1,0 +1,85 @@
+package com.animalleague.april.unit.professor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.animalleague.april.professor.application.SecurityContextCurrentUserProvider;
+
+class SecurityContextCurrentUserProviderUnitTest {
+
+    private final SecurityContextCurrentUserProvider provider = new SecurityContextCurrentUserProvider();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void currentUserIdReturnsUuidPrincipalAsIs() {
+        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(userId, "pw", "ROLE_USER"));
+
+        assertThat(provider.currentUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void currentUserIdReturnsUuidFromPublicAccessor() {
+        UUID userId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken(new PublicPrincipalWithId(userId), "pw", "ROLE_USER")
+        );
+
+        assertThat(provider.currentUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void currentUserIdFallsBackToAuthenticationNameWhenPrincipalIsNotResolvable() {
+        String username = "alice";
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken(new Object(), "pw", "ROLE_USER") {
+                @Override
+                public String getName() {
+                    return username;
+                }
+            }
+        );
+
+        assertThat(provider.currentUserId())
+            .isEqualTo(UUID.nameUUIDFromBytes(username.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void currentUserIdReturnsNullForAnonymousAuthentication() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+            )
+        );
+
+        assertThat(provider.currentUserId()).isNull();
+    }
+
+    public static final class PublicPrincipalWithId {
+        private final UUID id;
+
+        private PublicPrincipalWithId(UUID id) {
+            this.id = id;
+        }
+
+        public UUID getId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
## 요약

- 이 PR은 `#4 Task 1.4` 범위에서 교수 등록, 목록 조회, 상세 조회, 기본 호감도 초기화까지의 코어를 구현합니다.
- 이전에는 교수와 호감도 도메인, 저장소, API, 테스트 기반이 없어 사용자별 교수 등록과 현재 호감도 조회를 검증할 수 없었습니다. 이번 변경으로 인증 사용자 기준 교수/호감도 데이터가 함께 생성되고, 사진 유무에 따른 초기 캐릭터 에셋 상태가 계약 문서와 일치하도록 고정됩니다.
- `#3` 인증 구현은 섞지 않고 `#2` 공통 기반 위에서 `professor` 모듈만 추가했습니다.

## 연결된 이슈

- Closes #4
- 원칙: 한 이슈에 대한 작업이 끝나면 해당 이슈 기준으로 바로 PR을 생성한다.

## 작업 영역

- [ ] Front-end
- [x] Back-end

## 브랜치 / 배포 대상

- 소스 브랜치: `feat/back-end/4-professor-affection-registration-core`
- 대상 브랜치: `main`
- `issueNum`은 GitHub 이슈 번호 `#123`의 숫자 부분인 `123`을 의미한다.

## 변경 내용

- `professor` 도메인과 저장소를 추가해 교수와 호감도 데이터를 PostgreSQL에 저장할 수 있게 했습니다.
- 교수 등록 시 현재 인증 사용자 기준으로 `Professor`와 `Affection(0)`를 함께 생성하고, 목록/상세 조회도 같은 사용자 스코프로만 보이도록 제한했습니다.
- `sourcePhotoUrl` 유무에 따라 `characterAssetStatus`를 `pending` 또는 `ready`로 초기화하고, `isDefaultCharacterAssets`를 함께 고정했습니다.
- `V2__create_professor_affection_tables.sql`을 추가하고 호감도 점수 범위를 `0..100`으로 제한했습니다.
- 계약, 통합, 단위 테스트를 추가해 `gender` 검증 실패, 기본 호감도 생성, 인증 사용자 스코프, 미인증 401 응답을 검증했습니다.

## 테스트

- [ ] 구현 전에 실패하는 테스트를 먼저 추가했다.
- [ ] Front-end 테스트를 추가하거나 갱신했다.
- [x] Back-end 테스트를 추가하거나 갱신했다.
- [ ] CI가 통과했다.

실행한 검증:

- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:/usr/bin:/bin:/usr/sbin:/sbin ./gradlew unitTest --tests com.animalleague.april.unit.professor.AffectionInitializationUnitTest`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:/usr/bin:/bin:/usr/sbin:/sbin ./gradlew contractTest --tests com.animalleague.april.contract.professor.ProfessorContractTest`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:/usr/bin:/bin:/usr/sbin:/sbin ./gradlew integrationTest --tests com.animalleague.april.integration.professor.ProfessorRegistrationIntegrationTest`

## 문서

- [ ] `Docs/`의 버전 문서를 갱신했다.
- [ ] 필요 시 API 계약을 갱신했다.
- [ ] 교차 팀 차단 이슈가 있었다면 `FE-comment` / `BE-comment` 문서를 갱신했다.
- [x] 문서 영향이 없다.

## 리뷰 메모

- 중점적으로 봐야 할 영역: `SecurityContext`에서 현재 사용자 식별자를 추출하는 fallback, 사용자 스코프 조회, `sourcePhotoUrl` 분기에 따른 초기 상태 결정
- 알려진 후속 작업: `#5`에서 실제 캐릭터 에셋 생성 파이프라인과 `characterAssets`, `representativeAssetUrl` 연동이 이어집니다.
- 이 PR이 단일 이슈 완료 단위인지, 아니라면 왜 분리하지 않았는지: `#4 Task 1.4` 범위만 포함한 단일 이슈 완료 단위입니다.
- 리뷰 코멘트 응답 규칙: 지적사항을 반영했으면 반영한 내용을, 반영하지 않았으면 반영하지 않은 이유와 대안을 각 리뷰 코멘트 답글에 남긴다.

## Summary by Sourcery

Introduce professor registration and affection core domain and APIs scoped to the authenticated user, including persistence, security-based user resolution, and audit configuration.

New Features:
- Add professor and affection domain models with PostgreSQL migrations to store per-user professors and their affection scores.
- Expose REST endpoints to create professors, list a user’s professors, and fetch detailed professor data including affection and character asset metadata.
- Derive the current user from the Spring Security context via a pluggable provider, using username-based UUIDs as a fallback identifier.

Enhancements:
- Configure JPA auditing to use an OffsetDateTime-based DateTimeProvider for consistent timestamp handling across entities.

Tests:
- Add contract tests for professor APIs covering creation, listing, detail retrieval, and validation errors for invalid gender values.
- Add integration tests verifying affection initialization at zero, character asset initial state based on source photo presence, user-scoped access to professor data, and 401 responses for unauthenticated access.
- Add unit tests ensuring professor creation initializes affection for the authenticated user and enforces affection score bounds.