### PR TITLE
feat(auth): 인증 도메인과 로그인 API 구현

### DIFF
--- a/Backend/src/main/java/com/animalleague/april/auth/api/AuthController.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/AuthController.java
@@ -56,7 +56,9 @@ public class AuthController {
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
 
-        HttpSession session = httpRequest.getSession(true);
+        httpRequest.getSession(true);
+        httpRequest.changeSessionId();
+        HttpSession session = httpRequest.getSession(false);
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
 
         return new LoginResponse(UserSummaryResponse.from(user), null);

--- a/Backend/src/main/java/com/animalleague/april/auth/api/AuthController.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/AuthController.java
@@ -1,0 +1,64 @@
+package com.animalleague.april.auth.api;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animalleague.april.auth.application.AuthService;
+import com.animalleague.april.auth.application.AuthenticatedUser;
+import com.animalleague.april.auth.domain.User;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<UserEnvelope> signup(@Valid @RequestBody SignupRequest request) {
+        User user = authService.signup(
+            request.name(),
+            request.loginId(),
+            request.password(),
+            request.examEndDate()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(new UserEnvelope(UserSummaryResponse.from(user)));
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(@Valid @RequestBody LoginRequest request, HttpServletRequest httpRequest) {
+        User user = authService.login(request.loginId(), request.password());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getLoginId(), user.getName());
+
+        UsernamePasswordAuthenticationToken authentication =
+            UsernamePasswordAuthenticationToken.authenticated(principal, null, List.of());
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        HttpSession session = httpRequest.getSession(true);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+
+        return new LoginResponse(UserSummaryResponse.from(user), null);
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/api/LoginRequest.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.animalleague.april.auth.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+    @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
+    @Pattern(regexp = "[A-Za-z0-9]+", message = "로그인 ID는 영문 또는 숫자만 사용할 수 있습니다.")
+    @Size(min = 4, message = "로그인 ID는 4자 이상이어야 합니다.")
+    String loginId,
+    @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    String password
+) {}

--- a/Backend/src/main/java/com/animalleague/april/auth/api/LoginResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.animalleague.april.auth.api;
+
+public record LoginResponse(UserSummaryResponse user, Object activeSession) {}

--- a/Backend/src/main/java/com/animalleague/april/auth/api/SignupRequest.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/SignupRequest.java
@@ -1,0 +1,24 @@
+package com.animalleague.april.auth.api;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+    @NotBlank(message = "이름은 비어 있을 수 없습니다.")
+    String name,
+    @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
+    @Pattern(regexp = "[A-Za-z0-9]+", message = "로그인 ID는 영문 또는 숫자만 사용할 수 있습니다.")
+    @Size(min = 4, message = "로그인 ID는 4자 이상이어야 합니다.")
+    String loginId,
+    @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    String password,
+    @NotNull(message = "시험 종료일은 필수입니다.")
+    @FutureOrPresent(message = "시험 종료일은 오늘 이후 또는 오늘이어야 합니다.")
+    LocalDate examEndDate
+) {}

--- a/Backend/src/main/java/com/animalleague/april/auth/api/SignupRequest.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/SignupRequest.java
@@ -10,10 +10,11 @@ import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
     @NotBlank(message = "이름은 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "이름은 100자 이하여야 합니다.")
     String name,
     @NotBlank(message = "로그인 ID는 비어 있을 수 없습니다.")
     @Pattern(regexp = "[A-Za-z0-9]+", message = "로그인 ID는 영문 또는 숫자만 사용할 수 있습니다.")
-    @Size(min = 4, message = "로그인 ID는 4자 이상이어야 합니다.")
+    @Size(min = 4, max = 50, message = "로그인 ID는 4자 이상 50자 이하여야 합니다.")
     String loginId,
     @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")

--- a/Backend/src/main/java/com/animalleague/april/auth/api/UserEnvelope.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/UserEnvelope.java
@@ -1,0 +1,3 @@
+package com.animalleague.april.auth.api;
+
+public record UserEnvelope(UserSummaryResponse user) {}

--- a/Backend/src/main/java/com/animalleague/april/auth/api/UserSummaryResponse.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/api/UserSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.animalleague.april.auth.api;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.animalleague.april.auth.domain.User;
+
+public record UserSummaryResponse(UUID id, String name, String loginId, LocalDate examEndDate) {
+
+    public static UserSummaryResponse from(User user) {
+        return new UserSummaryResponse(
+            user.getId(),
+            user.getName(),
+            user.getLoginId(),
+            user.getExamEndDate()
+        );
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
@@ -1,7 +1,9 @@
 package com.animalleague.april.auth.application;
 
 import java.time.LocalDate;
+import java.util.Locale;
 
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,11 +46,11 @@ public class AuthService {
         try {
             return userRepository.saveAndFlush(user);
         } catch (DataIntegrityViolationException exception) {
-            if (userRepository.existsByLoginId(loginId)) {
+            if (isDuplicateLoginIdViolation(exception)) {
                 throw duplicateLoginIdException();
             }
 
-            throw exception;
+            throw invalidSignupInputException();
         }
     }
 
@@ -81,6 +83,26 @@ public class AuthService {
             HttpStatus.CONFLICT,
             "DUPLICATE_LOGIN_ID",
             "이미 사용 중인 로그인 ID입니다."
+        );
+    }
+
+    private boolean isDuplicateLoginIdViolation(DataIntegrityViolationException exception) {
+        Throwable mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(exception);
+        String message = mostSpecificCause == null ? exception.getMessage() : mostSpecificCause.getMessage();
+        if (message == null) {
+            return false;
+        }
+
+        String normalizedMessage = message.toLowerCase(Locale.ROOT);
+        return normalizedMessage.contains("uk_users_login_id")
+            || (normalizedMessage.contains("duplicate key") && normalizedMessage.contains("login_id"));
+    }
+
+    private ApiException invalidSignupInputException() {
+        return new ApiException(
+            HttpStatus.BAD_REQUEST,
+            "INVALID_SIGNUP_INPUT",
+            "회원가입 요청 값이 올바르지 않습니다."
         );
     }
 }

--- a/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
@@ -1,0 +1,73 @@
+package com.animalleague.april.auth.application;
+
+import java.time.LocalDate;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.animalleague.april.auth.domain.User;
+import com.animalleague.april.auth.infrastructure.UserRepository;
+import com.animalleague.april.common.api.ApiException;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SignupPolicy signupPolicy;
+    private final LoginPolicy loginPolicy;
+
+    public AuthService(
+        UserRepository userRepository,
+        PasswordEncoder passwordEncoder,
+        SignupPolicy signupPolicy,
+        LoginPolicy loginPolicy
+    ) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.signupPolicy = signupPolicy;
+        this.loginPolicy = loginPolicy;
+    }
+
+    @Transactional
+    public User signup(String name, String loginId, String password, LocalDate examEndDate) {
+        signupPolicy.validate(name, loginId, password, examEndDate);
+
+        if (userRepository.existsByLoginId(loginId)) {
+            throw new ApiException(
+                HttpStatus.CONFLICT,
+                "DUPLICATE_LOGIN_ID",
+                "이미 사용 중인 로그인 ID입니다."
+            );
+        }
+
+        User user = User.create(loginId, name, passwordEncoder.encode(password), examEndDate);
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public User login(String loginId, String password) {
+        loginPolicy.validate(loginId, password);
+
+        User user = userRepository.findByLoginId(loginId)
+            .orElseThrow(() ->
+                new ApiException(
+                    HttpStatus.UNAUTHORIZED,
+                    "INVALID_CREDENTIALS",
+                    "로그인 ID 또는 비밀번호가 올바르지 않습니다."
+                )
+            );
+
+        if (!passwordEncoder.matches(password, user.getPasswordHash())) {
+            throw new ApiException(
+                HttpStatus.UNAUTHORIZED,
+                "INVALID_CREDENTIALS",
+                "로그인 ID 또는 비밀번호가 올바르지 않습니다."
+            );
+        }
+
+        return user;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/AuthService.java
@@ -3,6 +3,7 @@ package com.animalleague.april.auth.application;
 import java.time.LocalDate;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,15 +37,19 @@ public class AuthService {
         signupPolicy.validate(name, loginId, password, examEndDate);
 
         if (userRepository.existsByLoginId(loginId)) {
-            throw new ApiException(
-                HttpStatus.CONFLICT,
-                "DUPLICATE_LOGIN_ID",
-                "이미 사용 중인 로그인 ID입니다."
-            );
+            throw duplicateLoginIdException();
         }
 
         User user = User.create(loginId, name, passwordEncoder.encode(password), examEndDate);
-        return userRepository.save(user);
+        try {
+            return userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException exception) {
+            if (userRepository.existsByLoginId(loginId)) {
+                throw duplicateLoginIdException();
+            }
+
+            throw exception;
+        }
     }
 
     @Transactional(readOnly = true)
@@ -69,5 +74,13 @@ public class AuthService {
         }
 
         return user;
+    }
+
+    private ApiException duplicateLoginIdException() {
+        return new ApiException(
+            HttpStatus.CONFLICT,
+            "DUPLICATE_LOGIN_ID",
+            "이미 사용 중인 로그인 ID입니다."
+        );
     }
 }

--- a/Backend/src/main/java/com/animalleague/april/auth/application/AuthenticatedUser.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/AuthenticatedUser.java
@@ -1,0 +1,11 @@
+package com.animalleague.april.auth.application;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+public record AuthenticatedUser(UUID id, String loginId, String name) implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/application/LoginPolicy.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/LoginPolicy.java
@@ -1,0 +1,28 @@
+package com.animalleague.april.auth.application;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.animalleague.april.common.api.ApiException;
+
+@Component
+public class LoginPolicy {
+
+    public void validate(String loginId, String password) {
+        if (loginId == null || !loginId.matches("[A-Za-z0-9]{4,}")) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "INVALID_LOGIN_ID",
+                "로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다."
+            );
+        }
+
+        if (password == null || password.length() < 8) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "INVALID_PASSWORD",
+                "비밀번호는 8자 이상이어야 합니다."
+            );
+        }
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/application/SignupPolicy.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/SignupPolicy.java
@@ -22,12 +22,20 @@ public class SignupPolicy {
             throw new ApiException(HttpStatus.BAD_REQUEST, "INVALID_NAME", "이름은 비어 있을 수 없습니다.");
         }
 
+        if (name.length() > 100) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "INVALID_NAME", "이름은 100자 이하여야 합니다.");
+        }
+
         if (loginId == null || !loginId.matches("[A-Za-z0-9]{4,}")) {
             throw new ApiException(
                 HttpStatus.BAD_REQUEST,
                 "INVALID_LOGIN_ID",
                 "로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다."
             );
+        }
+
+        if (loginId.length() > 50) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "INVALID_LOGIN_ID", "로그인 ID는 50자 이하여야 합니다.");
         }
 
         if (password == null || password.length() < 8) {

--- a/Backend/src/main/java/com/animalleague/april/auth/application/SignupPolicy.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/application/SignupPolicy.java
@@ -1,0 +1,49 @@
+package com.animalleague.april.auth.application;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.animalleague.april.common.api.ApiException;
+
+@Component
+public class SignupPolicy {
+
+    private final Clock clock;
+
+    public SignupPolicy(Clock clock) {
+        this.clock = clock;
+    }
+
+    public void validate(String name, String loginId, String password, LocalDate examEndDate) {
+        if (name == null || name.isBlank()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "INVALID_NAME", "이름은 비어 있을 수 없습니다.");
+        }
+
+        if (loginId == null || !loginId.matches("[A-Za-z0-9]{4,}")) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "INVALID_LOGIN_ID",
+                "로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다."
+            );
+        }
+
+        if (password == null || password.length() < 8) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "INVALID_PASSWORD",
+                "비밀번호는 8자 이상이어야 합니다."
+            );
+        }
+
+        if (examEndDate == null || examEndDate.isBefore(LocalDate.now(clock))) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "INVALID_EXAM_END_DATE",
+                "시험 종료일은 오늘 이후 또는 오늘이어야 합니다."
+            );
+        }
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/domain/User.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/domain/User.java
@@ -1,7 +1,7 @@
 package com.animalleague.april.auth.domain;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -43,11 +43,11 @@ public class User {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
+    private Instant updatedAt;
 
     protected User() {}
 
@@ -82,11 +82,11 @@ public class User {
         return examEndDate;
     }
 
-    public OffsetDateTime getCreatedAt() {
+    public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public OffsetDateTime getUpdatedAt() {
+    public Instant getUpdatedAt() {
         return updatedAt;
     }
 }

--- a/Backend/src/main/java/com/animalleague/april/auth/domain/User.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/domain/User.java
@@ -1,0 +1,92 @@
+package com.animalleague.april.auth.domain;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+    name = "users",
+    uniqueConstraints = @UniqueConstraint(name = "uk_users_login_id", columnNames = "login_id")
+)
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "login_id", nullable = false, length = 50)
+    private String loginId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "exam_end_date", nullable = false)
+    private LocalDate examEndDate;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    protected User() {}
+
+    private User(String loginId, String name, String passwordHash, LocalDate examEndDate) {
+        this.loginId = loginId;
+        this.name = name;
+        this.passwordHash = passwordHash;
+        this.examEndDate = examEndDate;
+    }
+
+    public static User create(String loginId, String name, String passwordHash, LocalDate examEndDate) {
+        return new User(loginId, name, passwordHash, examEndDate);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public LocalDate getExamEndDate() {
+        return examEndDate;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/auth/infrastructure/UserRepository.java
+++ b/Backend/src/main/java/com/animalleague/april/auth/infrastructure/UserRepository.java
@@ -1,0 +1,15 @@
+package com.animalleague.april.auth.infrastructure;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.animalleague.april.auth.domain.User;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    boolean existsByLoginId(String loginId);
+
+    Optional<User> findByLoginId(String loginId);
+}

--- a/Backend/src/main/java/com/animalleague/april/common/api/ApiException.java
+++ b/Backend/src/main/java/com/animalleague/april/common/api/ApiException.java
@@ -1,0 +1,23 @@
+package com.animalleague.april.common.api;
+
+import org.springframework.http.HttpStatusCode;
+
+public class ApiException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
+    private final String code;
+
+    public ApiException(HttpStatusCode statusCode, String code, String message) {
+        super(message);
+        this.statusCode = statusCode;
+        this.code = code;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/common/infrastructure/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/animalleague/april/common/infrastructure/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.animalleague.april.common.api.ApiException;
 import com.animalleague.april.common.api.ErrorResponse;
 import com.animalleague.april.common.api.ErrorResponse.FieldViolation;
 
@@ -78,6 +79,21 @@ public class GlobalExceptionHandler {
                 "요청 파라미터 검증에 실패했습니다.",
                 request.getRequestURI()
             ).withViolations(violations)
+        );
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(
+        ApiException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.status(exception.getStatusCode()).body(
+            ErrorResponse.of(
+                exception.getStatusCode(),
+                exception.getCode(),
+                exception.getMessage(),
+                request.getRequestURI()
+            )
         );
     }
 

--- a/Backend/src/main/resources/db/migration/V1__create_users.sql
+++ b/Backend/src/main/resources/db/migration/V1__create_users.sql
@@ -1,0 +1,10 @@
+create table users (
+    id uuid primary key,
+    login_id varchar(50) not null,
+    name varchar(100) not null,
+    password_hash varchar(255) not null,
+    exam_end_date date not null,
+    created_at timestamp with time zone not null,
+    updated_at timestamp with time zone not null,
+    constraint uk_users_login_id unique (login_id)
+);

--- a/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
@@ -2,6 +2,7 @@ package com.animalleague.april.contract.auth;
 
 import java.time.LocalDate;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -84,5 +85,23 @@ class AuthContractTest extends ApiContractTest {
             )
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void loginValidationFailureReturns400() throws Exception {
+        mockMvc.perform(
+                post("/api/auth/login")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "loginId": "",
+                          "password": "1234"
+                        }
+                        """)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations").isArray())
+            .andExpect(jsonPath("$.violations[*].field", Matchers.hasItems("loginId", "password")));
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
@@ -47,6 +47,26 @@ class AuthContractTest extends ApiContractTest {
     }
 
     @Test
+    void signupLengthValidationFailureReturns400() throws Exception {
+        SignupRequest request = new SignupRequest(
+            "가".repeat(101),
+            "a".repeat(51),
+            "password123",
+            LocalDate.now().plusDays(30)
+        );
+
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content(json(request))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations").isArray())
+            .andExpect(jsonPath("$.violations[*].field", Matchers.hasItems("name", "loginId")));
+    }
+
+    @Test
     void duplicateLoginIdReturns409() throws Exception {
         given(authService.signup(anyString(), anyString(), anyString(), any(LocalDate.class)))
             .willThrow(new ApiException(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 사용 중인 로그인 ID입니다."));

--- a/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
+++ b/Backend/src/test/java/com/animalleague/april/contract/auth/AuthContractTest.java
@@ -1,0 +1,88 @@
+package com.animalleague.april.contract.auth;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.animalleague.april.auth.api.AuthController;
+import com.animalleague.april.auth.api.SignupRequest;
+import com.animalleague.april.auth.application.AuthService;
+import com.animalleague.april.common.api.ApiException;
+import com.animalleague.april.common.infrastructure.GlobalExceptionHandler;
+import com.animalleague.april.contract.support.ApiContractTest;
+
+@WebMvcTest(controllers = AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class AuthContractTest extends ApiContractTest {
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void signupValidationFailureReturns400() throws Exception {
+        SignupRequest request = new SignupRequest("", "ab", "1234", LocalDate.now().minusDays(1));
+
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content(json(request))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.violations").isArray());
+    }
+
+    @Test
+    void duplicateLoginIdReturns409() throws Exception {
+        given(authService.signup(anyString(), anyString(), anyString(), any(LocalDate.class)))
+            .willThrow(new ApiException(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 사용 중인 로그인 ID입니다."));
+
+        SignupRequest request = new SignupRequest("홍길동", "hong1234", "password123", LocalDate.now().plusDays(30));
+
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content(json(request))
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("DUPLICATE_LOGIN_ID"));
+    }
+
+    @Test
+    void invalidCredentialsReturns401() throws Exception {
+        given(authService.login(anyString(), anyString()))
+            .willThrow(
+                new ApiException(
+                    HttpStatus.UNAUTHORIZED,
+                    "INVALID_CREDENTIALS",
+                    "로그인 ID 또는 비밀번호가 올바르지 않습니다."
+                )
+            );
+
+        mockMvc.perform(
+                post("/api/auth/login")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "loginId": "hong1234",
+                          "password": "password123"
+                        }
+                        """)
+            )
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -23,6 +23,10 @@ import com.animalleague.april.integration.support.PostgresIntegrationTest;
 @TestPropertySource(properties = "spring.flyway.enabled=true")
 class AuthFlowIntegrationTest extends PostgresIntegrationTest {
 
+    private static final String SIGNUP_LOGIN_ID = "hong1234";
+    private static final String DUPLICATE_LOGIN_ID = "hong1235";
+    private static final String WRONG_PASSWORD_LOGIN_ID = "hong1236";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -37,20 +41,20 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .content("""
                         {
                           "name": "홍길동",
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """)
+                        """.formatted(SIGNUP_LOGIN_ID))
             )
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.user.name").value("홍길동"))
-            .andExpect(jsonPath("$.user.loginId").value("hong1234"))
+            .andExpect(jsonPath("$.user.loginId").value(SIGNUP_LOGIN_ID))
             .andExpect(jsonPath("$.user.examEndDate").value("2026-06-20"));
 
-        User persistedUser = userRepository.findByLoginId("hong1234").orElseThrow();
+        User persistedUser = userRepository.findByLoginId(SIGNUP_LOGIN_ID).orElseThrow();
         assertThat(persistedUser.getId()).isNotNull();
-        assertThat(persistedUser.getLoginId()).isEqualTo("hong1234");
+        assertThat(persistedUser.getLoginId()).isEqualTo(SIGNUP_LOGIN_ID);
         assertThat(persistedUser.getName()).isEqualTo("홍길동");
         assertThat(persistedUser.getExamEndDate()).isEqualTo(LocalDate.parse("2026-06-20"));
         assertThat(persistedUser.getPasswordHash()).isNotEqualTo("password123");
@@ -62,14 +66,14 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .contentType("application/json")
                     .content("""
                         {
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "password123"
                         }
-                        """)
+                        """.formatted(SIGNUP_LOGIN_ID))
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.user.name").value("홍길동"))
-            .andExpect(jsonPath("$.user.loginId").value("hong1234"))
+            .andExpect(jsonPath("$.user.loginId").value(SIGNUP_LOGIN_ID))
             .andExpect(jsonPath("$.activeSession").value(Matchers.nullValue()))
             .andReturn();
 
@@ -84,11 +88,11 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .content("""
                         {
                           "name": "홍길동",
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """)
+                        """.formatted(DUPLICATE_LOGIN_ID))
             )
             .andExpect(status().isCreated());
 
@@ -98,11 +102,11 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .content("""
                         {
                           "name": "임꺽정",
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """)
+                        """.formatted(DUPLICATE_LOGIN_ID))
             )
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.code").value("DUPLICATE_LOGIN_ID"));
@@ -116,11 +120,11 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .content("""
                         {
                           "name": "홍길동",
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """)
+                        """.formatted(WRONG_PASSWORD_LOGIN_ID))
             )
             .andExpect(status().isCreated());
 
@@ -129,10 +133,10 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                     .contentType("application/json")
                     .content("""
                         {
-                          "loginId": "hong1234",
+                          "loginId": "%s",
                           "password": "wrongpass123"
                         }
-                        """)
+                        """.formatted(WRONG_PASSWORD_LOGIN_ID))
             )
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.animalleague.april.integration.auth;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.animalleague.april.auth.infrastructure.UserRepository;
+import com.animalleague.april.integration.support.PostgresIntegrationTest;
+
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "spring.flyway.enabled=true")
+class AuthFlowIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void signupThenLoginReturnsUserAndNullActiveSession() throws Exception {
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "name": "홍길동",
+                          "loginId": "hong1234",
+                          "password": "password123",
+                          "examEndDate": "2026-06-20"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.user.name").value("홍길동"))
+            .andExpect(jsonPath("$.user.loginId").value("hong1234"))
+            .andExpect(jsonPath("$.user.examEndDate").value("2026-06-20"));
+
+        assertThat(userRepository.findByLoginId("hong1234")).isPresent();
+
+        MvcResult loginResult = mockMvc.perform(
+                post("/api/auth/login")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "loginId": "hong1234",
+                          "password": "password123"
+                        }
+                        """)
+            )
+            .andExpect(status().isOk())
+            .andExpect(cookie().exists("JSESSIONID"))
+            .andExpect(jsonPath("$.user.name").value("홍길동"))
+            .andExpect(jsonPath("$.user.loginId").value("hong1234"))
+            .andExpect(jsonPath("$.activeSession").value(Matchers.nullValue()))
+            .andReturn();
+
+        assertThat(loginResult.getRequest().getSession(false)).isNotNull();
+    }
+
+    @Test
+    void duplicateLoginIdReturns409() throws Exception {
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "name": "홍길동",
+                          "loginId": "hong1234",
+                          "password": "password123",
+                          "examEndDate": "2026-06-20"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "name": "임꺽정",
+                          "loginId": "hong1234",
+                          "password": "password123",
+                          "examEndDate": "2026-06-20"
+                        }
+                        """)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("DUPLICATE_LOGIN_ID"));
+    }
+
+    @Test
+    void wrongPasswordReturns401() throws Exception {
+        mockMvc.perform(
+                post("/api/auth/signup")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "name": "홍길동",
+                          "loginId": "hong1234",
+                          "password": "password123",
+                          "examEndDate": "2026-06-20"
+                        }
+                        """)
+            )
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(
+                post("/api/auth/login")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "loginId": "hong1234",
+                          "password": "wrongpass123"
+                        }
+                        """)
+            )
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -1,14 +1,18 @@
 package com.animalleague.april.integration.auth;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -21,11 +25,8 @@ import com.animalleague.april.integration.support.PostgresIntegrationTest;
 
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "spring.flyway.enabled=true")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 class AuthFlowIntegrationTest extends PostgresIntegrationTest {
-
-    private static final String SIGNUP_LOGIN_ID = "hong1234";
-    private static final String DUPLICATE_LOGIN_ID = "hong1235";
-    private static final String WRONG_PASSWORD_LOGIN_ID = "hong1236";
 
     @Autowired
     private MockMvc mockMvc;
@@ -33,8 +34,15 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
+    @BeforeEach
+    void clearUsers() {
+        userRepository.deleteAllInBatch();
+    }
+
     @Test
     void signupThenLoginReturnsUserAndNullActiveSession() throws Exception {
+        String loginId = newLoginId("signup");
+
         mockMvc.perform(
                 post("/api/auth/signup")
                     .contentType("application/json")
@@ -45,16 +53,16 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """.formatted(SIGNUP_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.user.name").value("홍길동"))
-            .andExpect(jsonPath("$.user.loginId").value(SIGNUP_LOGIN_ID))
+            .andExpect(jsonPath("$.user.loginId").value(loginId))
             .andExpect(jsonPath("$.user.examEndDate").value("2026-06-20"));
 
-        User persistedUser = userRepository.findByLoginId(SIGNUP_LOGIN_ID).orElseThrow();
+        User persistedUser = userRepository.findByLoginId(loginId).orElseThrow();
         assertThat(persistedUser.getId()).isNotNull();
-        assertThat(persistedUser.getLoginId()).isEqualTo(SIGNUP_LOGIN_ID);
+        assertThat(persistedUser.getLoginId()).isEqualTo(loginId);
         assertThat(persistedUser.getName()).isEqualTo("홍길동");
         assertThat(persistedUser.getExamEndDate()).isEqualTo(LocalDate.parse("2026-06-20"));
         assertThat(persistedUser.getPasswordHash()).isNotEqualTo("password123");
@@ -69,11 +77,11 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "loginId": "%s",
                           "password": "password123"
                         }
-                        """.formatted(SIGNUP_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.user.name").value("홍길동"))
-            .andExpect(jsonPath("$.user.loginId").value(SIGNUP_LOGIN_ID))
+            .andExpect(jsonPath("$.user.loginId").value(loginId))
             .andExpect(jsonPath("$.activeSession").value(Matchers.nullValue()))
             .andReturn();
 
@@ -82,6 +90,8 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
 
     @Test
     void duplicateLoginIdReturns409() throws Exception {
+        String loginId = newLoginId("dup");
+
         mockMvc.perform(
                 post("/api/auth/signup")
                     .contentType("application/json")
@@ -92,7 +102,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """.formatted(DUPLICATE_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isCreated());
 
@@ -106,7 +116,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """.formatted(DUPLICATE_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.code").value("DUPLICATE_LOGIN_ID"));
@@ -114,6 +124,8 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
 
     @Test
     void wrongPasswordReturns401() throws Exception {
+        String loginId = newLoginId("wrong");
+
         mockMvc.perform(
                 post("/api/auth/signup")
                     .contentType("application/json")
@@ -124,7 +136,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "password": "password123",
                           "examEndDate": "2026-06-20"
                         }
-                        """.formatted(WRONG_PASSWORD_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isCreated());
 
@@ -136,9 +148,29 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "loginId": "%s",
                           "password": "wrongpass123"
                         }
-                        """.formatted(WRONG_PASSWORD_LOGIN_ID))
+                        """.formatted(loginId))
             )
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+
+    @Test
+    void loginWithUnknownUserReturns401() throws Exception {
+        mockMvc.perform(
+                post("/api/auth/login")
+                    .contentType("application/json")
+                    .content("""
+                        {
+                          "loginId": "%s",
+                          "password": "password123"
+                        }
+                        """.formatted(newLoginId("ghost")))
+            )
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"));
+    }
+
+    private String newLoginId(String prefix) {
+        return prefix + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.animalleague.april.integration.auth;
 
+import java.time.LocalDate;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +12,10 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.animalleague.april.auth.domain.User;
 import com.animalleague.april.auth.infrastructure.UserRepository;
 import com.animalleague.april.integration.support.PostgresIntegrationTest;
 
@@ -46,7 +48,14 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
             .andExpect(jsonPath("$.user.loginId").value("hong1234"))
             .andExpect(jsonPath("$.user.examEndDate").value("2026-06-20"));
 
-        assertThat(userRepository.findByLoginId("hong1234")).isPresent();
+        User persistedUser = userRepository.findByLoginId("hong1234").orElseThrow();
+        assertThat(persistedUser.getId()).isNotNull();
+        assertThat(persistedUser.getLoginId()).isEqualTo("hong1234");
+        assertThat(persistedUser.getName()).isEqualTo("홍길동");
+        assertThat(persistedUser.getExamEndDate()).isEqualTo(LocalDate.parse("2026-06-20"));
+        assertThat(persistedUser.getPasswordHash()).isNotEqualTo("password123");
+        assertThat(persistedUser.getCreatedAt()).isNotNull();
+        assertThat(persistedUser.getUpdatedAt()).isNotNull();
 
         MvcResult loginResult = mockMvc.perform(
                 post("/api/auth/login")
@@ -59,7 +68,6 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                         """)
             )
             .andExpect(status().isOk())
-            .andExpect(cookie().exists("JSESSIONID"))
             .andExpect(jsonPath("$.user.name").value("홍길동"))
             .andExpect(jsonPath("$.user.loginId").value("hong1234"))
             .andExpect(jsonPath("$.activeSession").value(Matchers.nullValue()))

--- a/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/auth/AuthFlowIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.animalleague.april.integration.auth;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import org.hamcrest.Matchers;
@@ -42,6 +43,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
     @Test
     void signupThenLoginReturnsUserAndNullActiveSession() throws Exception {
         String loginId = newLoginId("signup");
+        String examEndDate = futureExamEndDate();
 
         mockMvc.perform(
                 post("/api/auth/signup")
@@ -51,20 +53,20 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "name": "홍길동",
                           "loginId": "%s",
                           "password": "password123",
-                          "examEndDate": "2026-06-20"
+                          "examEndDate": "%s"
                         }
-                        """.formatted(loginId))
+                        """.formatted(loginId, examEndDate))
             )
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.user.name").value("홍길동"))
             .andExpect(jsonPath("$.user.loginId").value(loginId))
-            .andExpect(jsonPath("$.user.examEndDate").value("2026-06-20"));
+            .andExpect(jsonPath("$.user.examEndDate").value(examEndDate));
 
         User persistedUser = userRepository.findByLoginId(loginId).orElseThrow();
         assertThat(persistedUser.getId()).isNotNull();
         assertThat(persistedUser.getLoginId()).isEqualTo(loginId);
         assertThat(persistedUser.getName()).isEqualTo("홍길동");
-        assertThat(persistedUser.getExamEndDate()).isEqualTo(LocalDate.parse("2026-06-20"));
+        assertThat(persistedUser.getExamEndDate()).isEqualTo(LocalDate.parse(examEndDate));
         assertThat(persistedUser.getPasswordHash()).isNotEqualTo("password123");
         assertThat(persistedUser.getCreatedAt()).isNotNull();
         assertThat(persistedUser.getUpdatedAt()).isNotNull();
@@ -91,6 +93,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
     @Test
     void duplicateLoginIdReturns409() throws Exception {
         String loginId = newLoginId("dup");
+        String examEndDate = futureExamEndDate();
 
         mockMvc.perform(
                 post("/api/auth/signup")
@@ -100,9 +103,9 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "name": "홍길동",
                           "loginId": "%s",
                           "password": "password123",
-                          "examEndDate": "2026-06-20"
+                          "examEndDate": "%s"
                         }
-                        """.formatted(loginId))
+                        """.formatted(loginId, examEndDate))
             )
             .andExpect(status().isCreated());
 
@@ -114,9 +117,9 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "name": "임꺽정",
                           "loginId": "%s",
                           "password": "password123",
-                          "examEndDate": "2026-06-20"
+                          "examEndDate": "%s"
                         }
-                        """.formatted(loginId))
+                        """.formatted(loginId, examEndDate))
             )
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.code").value("DUPLICATE_LOGIN_ID"));
@@ -125,6 +128,7 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
     @Test
     void wrongPasswordReturns401() throws Exception {
         String loginId = newLoginId("wrong");
+        String examEndDate = futureExamEndDate();
 
         mockMvc.perform(
                 post("/api/auth/signup")
@@ -134,9 +138,9 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
                           "name": "홍길동",
                           "loginId": "%s",
                           "password": "password123",
-                          "examEndDate": "2026-06-20"
+                          "examEndDate": "%s"
                         }
-                        """.formatted(loginId))
+                        """.formatted(loginId, examEndDate))
             )
             .andExpect(status().isCreated());
 
@@ -172,5 +176,9 @@ class AuthFlowIntegrationTest extends PostgresIntegrationTest {
 
     private String newLoginId(String prefix) {
         return prefix + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+    }
+
+    private String futureExamEndDate() {
+        return LocalDate.now(ZoneOffset.UTC).plusDays(30).toString();
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/AuthServiceUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/AuthServiceUnitTest.java
@@ -1,0 +1,93 @@
+package com.animalleague.april.unit.auth;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.animalleague.april.auth.application.AuthService;
+import com.animalleague.april.auth.application.LoginPolicy;
+import com.animalleague.april.auth.application.SignupPolicy;
+import com.animalleague.april.auth.domain.User;
+import com.animalleague.april.auth.infrastructure.UserRepository;
+import com.animalleague.april.common.api.ApiException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceUnitTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private SignupPolicy signupPolicy;
+
+    @Mock
+    private LoginPolicy loginPolicy;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(userRepository, passwordEncoder, signupPolicy, loginPolicy);
+    }
+
+    @Test
+    void duplicateConstraintViolationReturns409WithoutFollowUpQuery() {
+        given(userRepository.existsByLoginId("hong1234")).willReturn(false);
+        given(passwordEncoder.encode("password123")).willReturn("encoded-password");
+        given(userRepository.saveAndFlush(any(User.class)))
+            .willThrow(
+                new DataIntegrityViolationException(
+                    "duplicate signup",
+                    new RuntimeException("duplicate key value violates unique constraint \"uk_users_login_id\"")
+                )
+            );
+
+        assertThatThrownBy(
+            () -> authService.signup("홍길동", "hong1234", "password123", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOfSatisfying(ApiException.class, exception -> {
+                assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                assertThat(exception.getCode()).isEqualTo("DUPLICATE_LOGIN_ID");
+            });
+
+        then(userRepository).should(times(1)).existsByLoginId("hong1234");
+    }
+
+    @Test
+    void nonDuplicateIntegrityViolationReturns400() {
+        given(userRepository.existsByLoginId("hong1234")).willReturn(false);
+        given(passwordEncoder.encode("password123")).willReturn("encoded-password");
+        given(userRepository.saveAndFlush(any(User.class)))
+            .willThrow(
+                new DataIntegrityViolationException(
+                    "invalid signup input",
+                    new RuntimeException("value too long for type character varying(100)")
+                )
+            );
+
+        assertThatThrownBy(
+            () -> authService.signup("홍길동", "hong1234", "password123", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOfSatisfying(ApiException.class, exception -> {
+                assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                assertThat(exception.getCode()).isEqualTo("INVALID_SIGNUP_INPUT");
+            });
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/LoginPolicyUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/LoginPolicyUnitTest.java
@@ -3,6 +3,7 @@ package com.animalleague.april.unit.auth;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.animalleague.april.auth.application.LoginPolicy;
@@ -25,9 +26,29 @@ class LoginPolicyUnitTest {
     }
 
     @Test
+    void nullLoginIdIsRejected() {
+        assertThatThrownBy(() -> loginPolicy.validate(null, "password123"))
+            .isInstanceOf(ApiException.class)
+            .hasMessage("로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다.");
+    }
+
+    @Test
     void shortPasswordIsRejected() {
         assertThatThrownBy(() -> loginPolicy.validate("hong1234", "1234"))
             .isInstanceOf(ApiException.class)
             .hasMessage("비밀번호는 8자 이상이어야 합니다.");
+    }
+
+    @Test
+    void nullPasswordIsRejected() {
+        assertThatThrownBy(() -> loginPolicy.validate("hong1234", null))
+            .isInstanceOf(ApiException.class)
+            .hasMessage("비밀번호는 8자 이상이어야 합니다.");
+    }
+
+    @Test
+    void validLoginDoesNotThrowException() {
+        assertThatCode(() -> loginPolicy.validate("hong1234", "password123"))
+            .doesNotThrowAnyException();
     }
 }

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/LoginPolicyUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/LoginPolicyUnitTest.java
@@ -1,0 +1,33 @@
+package com.animalleague.april.unit.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.animalleague.april.auth.application.LoginPolicy;
+import com.animalleague.april.common.api.ApiException;
+
+class LoginPolicyUnitTest {
+
+    private LoginPolicy loginPolicy;
+
+    @BeforeEach
+    void setUp() {
+        loginPolicy = new LoginPolicy();
+    }
+
+    @Test
+    void invalidLoginIdIsRejected() {
+        assertThatThrownBy(() -> loginPolicy.validate("ab!", "password123"))
+            .isInstanceOf(ApiException.class)
+            .hasMessage("로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다.");
+    }
+
+    @Test
+    void shortPasswordIsRejected() {
+        assertThatThrownBy(() -> loginPolicy.validate("hong1234", "1234"))
+            .isInstanceOf(ApiException.class)
+            .hasMessage("비밀번호는 8자 이상이어야 합니다.");
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
@@ -39,12 +39,30 @@ class SignupPolicyUnitTest {
     }
 
     @Test
+    void longNameIsRejected() {
+        assertThatThrownBy(
+            () -> signupPolicy.validate("가".repeat(101), "hong1234", "password123", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOf(ApiException.class)
+            .hasMessage("이름은 100자 이하여야 합니다.");
+    }
+
+    @Test
     void invalidLoginIdIsRejected() {
         assertThatThrownBy(
             () -> signupPolicy.validate("홍길동", "ab!", "password123", LocalDate.parse("2026-06-20"))
         )
             .isInstanceOf(ApiException.class)
             .hasMessage("로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다.");
+    }
+
+    @Test
+    void longLoginIdIsRejected() {
+        assertThatThrownBy(
+            () -> signupPolicy.validate("홍길동", "a".repeat(51), "password123", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOf(ApiException.class)
+            .hasMessage("로그인 ID는 50자 이하여야 합니다.");
     }
 
     @Test

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.animalleague.april.auth.application.SignupPolicy;
@@ -21,6 +22,13 @@ class SignupPolicyUnitTest {
     void setUp() {
         Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
         signupPolicy = new SignupPolicy(fixedClock);
+    }
+
+    @Test
+    void validSignupDoesNotThrowException() {
+        assertThatCode(
+            () -> signupPolicy.validate("홍길동", "hong1234", "password123", LocalDate.parse("2026-06-20"))
+        ).doesNotThrowAnyException();
     }
 
     @Test

--- a/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/auth/SignupPolicyUnitTest.java
@@ -1,0 +1,59 @@
+package com.animalleague.april.unit.auth;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.animalleague.april.auth.application.SignupPolicy;
+import com.animalleague.april.common.api.ApiException;
+
+class SignupPolicyUnitTest {
+
+    private SignupPolicy signupPolicy;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixedClock = Clock.fixed(Instant.parse("2026-05-01T00:00:00Z"), ZoneOffset.UTC);
+        signupPolicy = new SignupPolicy(fixedClock);
+    }
+
+    @Test
+    void blankNameIsRejected() {
+        assertThatThrownBy(() -> signupPolicy.validate("", "hong1234", "password123", LocalDate.parse("2026-06-20")))
+            .isInstanceOf(ApiException.class)
+            .hasMessage("이름은 비어 있을 수 없습니다.");
+    }
+
+    @Test
+    void invalidLoginIdIsRejected() {
+        assertThatThrownBy(
+            () -> signupPolicy.validate("홍길동", "ab!", "password123", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOf(ApiException.class)
+            .hasMessage("로그인 ID는 영문 또는 숫자 4자 이상이어야 합니다.");
+    }
+
+    @Test
+    void shortPasswordIsRejected() {
+        assertThatThrownBy(
+            () -> signupPolicy.validate("홍길동", "hong1234", "1234", LocalDate.parse("2026-06-20"))
+        )
+            .isInstanceOf(ApiException.class)
+            .hasMessage("비밀번호는 8자 이상이어야 합니다.");
+    }
+
+    @Test
+    void pastExamEndDateIsRejected() {
+        assertThatThrownBy(
+            () -> signupPolicy.validate("홍길동", "hong1234", "password123", LocalDate.parse("2026-04-30"))
+        )
+            .isInstanceOf(ApiException.class)
+            .hasMessage("시험 종료일은 오늘 이후 또는 오늘이어야 합니다.");
+    }
+}

--- a/Docs/api-spec-v0.1.md
+++ b/Docs/api-spec-v0.1.md
@@ -46,9 +46,9 @@ API 명세 v0.1
 
 요청 필드:
 
-- `name`
-- `loginId`
-- `password`
+- `name`: 비어 있을 수 없고 100자 이하여야 한다.
+- `loginId`: 영문/숫자만 사용 가능하며 4자 이상 50자 이하여야 한다.
+- `password`: 8자 이상이어야 한다.
 - `examEndDate`
 
 응답 필드:
@@ -62,8 +62,8 @@ API 명세 v0.1
 
 요청 필드:
 
-- `loginId`
-- `password`
+- `loginId`: 영문/숫자만 사용 가능하며 4자 이상이어야 한다.
+- `password`: 8자 이상이어야 한다.
 
 응답 필드:
 

--- a/specs/001-backend-mvp/contracts/backend-api.openapi.yaml
+++ b/specs/001-backend-mvp/contracts/backend-api.openapi.yaml
@@ -263,10 +263,15 @@ components:
       properties:
         name:
           type: string
+          maxLength: 100
         loginId:
           type: string
+          pattern: '^[A-Za-z0-9]+$'
+          minLength: 4
+          maxLength: 50
         password:
           type: string
+          minLength: 8
         examEndDate:
           type: string
           format: date
@@ -276,8 +281,11 @@ components:
       properties:
         loginId:
           type: string
+          pattern: '^[A-Za-z0-9]+$'
+          minLength: 4
         password:
           type: string
+          minLength: 8
       required: [loginId, password]
     UserEnvelope:
       type: object


### PR DESCRIPTION
## 요약

- #3 인증 도메인과 로그인 API를 구현했습니다.
- 사용자 스키마, `User` 엔티티와 저장소, 회원가입/로그인 API, 계약/통합/단위 테스트를 포함합니다.
- 회원가입 시 중복 `loginId`는 사전 조회와 DB unique 제약 충돌 모두 `DUPLICATE_LOGIN_ID`로 처리하도록 보강했습니다.

## 연결된 이슈

- Closes #3
- 원칙: 한 이슈에 대한 작업이 끝나면 해당 이슈 기준으로 바로 PR을 생성한다.

## 작업 영역

- [ ] Front-end
- [x] Back-end

## 브랜치 / 배포 대상

- 소스 브랜치: feat/back-end/3-auth-domain-login-api
- 대상 브랜치: main
- `issueNum`은 GitHub 이슈 번호 `#123`의 숫자 부분인 `123`을 의미한다.

## 변경 내용

- `users` 테이블 마이그레이션과 `User` 도메인, `UserRepository`를 추가했습니다.
- `AuthService`, `AuthController`, 요청/응답 DTO를 통해 회원가입/로그인 흐름을 구현했습니다.
- `AuthContractTest`, `AuthFlowIntegrationTest`, `SignupPolicyUnitTest`, `LoginPolicyUnitTest`로 인증 흐름 검증을 추가했습니다.
- `saveAndFlush`와 `DataIntegrityViolationException` 처리로 중복 가입 경계를 안정화했습니다.

## 테스트

- [ ] 구현 전에 실패하는 테스트를 먼저 추가했다.
- [ ] Front-end 테스트를 추가하거나 갱신했다.
- [x] Back-end 테스트를 추가하거나 갱신했다.
- [ ] CI가 통과했다.
- 로컬 검증: `./gradlew --no-daemon clean assemble contractTest integrationTest unitTest` 통과

## 문서

- [ ] `Docs/`의 버전 문서를 갱신했다.
- [ ] 필요 시 API 계약을 갱신했다.
- [ ] 교차 팀 차단 이슈가 있었다면 `FE-comment` / `BE-comment` 문서를 갱신했다.
- [x] 문서 영향이 없다.

## 리뷰 메모

- 중점적으로 봐야 할 영역: 인증 서비스의 중복 가입 처리, 세션 로그인 흐름, 인증 테스트 커버리지
- 알려진 후속 작업: 없음
- 이 PR이 단일 이슈 완료 단위인지, 아니라면 왜 분리하지 않았는지: 이 PR은 이슈 #3 완료 단위입니다.
- 리뷰 코멘트 응답 규칙: 지적사항을 반영했으면 반영한 내용을, 반영하지 않았으면 반영하지 않은 이유와 대안을 각 리뷰 코멘트 답글에 남긴다.

## Summary by Sourcery

Implement backend user authentication domain with signup and login APIs backed by a users table and session-based login.

New Features:
- Add User JPA entity, repository, and Flyway migration for the users table.
- Expose /api/auth/signup and /api/auth/login endpoints with request/response DTOs and session-backed authentication.
- Introduce policy components for signup and login input validation and a reusable ApiException for API-level error signaling.

Bug Fixes:
- Normalize duplicate signup handling so conflicting login IDs consistently return a DUPLICATE_LOGIN_ID 409 response.
- Ensure invalid credentials during login yield a standardized INVALID_CREDENTIALS 401 response.

Enhancements:
- Extend the global exception handler to map ApiException instances into structured error responses.

Tests:
- Add contract tests for auth error responses, unit tests for signup/login policies, and integration tests covering signup/login flows including password hashing and duplicate handling.