### PR TITLE
feat(backend): 캐릭터 에셋 생성 파이프라인

### DIFF
--- a/Backend/src/main/java/com/animalleague/april/professor/application/DefaultCharacterAssetCatalog.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/DefaultCharacterAssetCatalog.java
@@ -1,0 +1,98 @@
+package com.animalleague.april.professor.application;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+
+import com.animalleague.april.common.domain.PersonalityType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class DefaultCharacterAssetCatalog {
+
+    private static final String RESOURCE_PATH = "classpath:seed/characters/default-character-assets.json";
+
+    private final Map<PersonalityType, DefaultCharacterAssetSet> assetSets;
+
+    public DefaultCharacterAssetCatalog(ObjectMapper objectMapper, ResourceLoader resourceLoader) {
+        this.assetSets = loadCatalog(objectMapper, resourceLoader);
+    }
+
+    public DefaultCharacterAssetSet getAssetSet(PersonalityType personalityType) {
+        DefaultCharacterAssetSet assetSet = assetSets.get(personalityType);
+        if (assetSet == null) {
+            throw new IllegalArgumentException("기본 캐릭터 에셋이 정의되지 않은 personalityType 입니다: " + personalityType.value());
+        }
+        return assetSet;
+    }
+
+    private Map<PersonalityType, DefaultCharacterAssetSet> loadCatalog(
+        ObjectMapper objectMapper,
+        ResourceLoader resourceLoader
+    ) {
+        try (InputStream inputStream = resourceLoader.getResource(RESOURCE_PATH).getInputStream()) {
+            CatalogDocument catalog = objectMapper.readValue(inputStream, CatalogDocument.class);
+            return catalog.personalities().stream()
+                .map(entry -> new DefaultCharacterAssetSet(
+                    PersonalityType.fromValue(entry.personalityType()),
+                    entry.representativeVariantKey(),
+                    entry.assets().stream()
+                        .map(asset -> new DefaultCharacterAsset(asset.variantKey(), asset.imageUrl()))
+                        .toList()
+                ))
+                .collect(Collectors.toUnmodifiableMap(DefaultCharacterAssetSet::personalityType, Function.identity()));
+        } catch (IOException exception) {
+            throw new UncheckedIOException("기본 캐릭터 에셋 카탈로그를 불러오지 못했습니다.", exception);
+        }
+    }
+
+    public record DefaultCharacterAssetSet(
+        PersonalityType personalityType,
+        String representativeVariantKey,
+        List<DefaultCharacterAsset> assets
+    ) {
+
+        public DefaultCharacterAssetSet {
+            assets = List.copyOf(assets);
+        }
+
+        public List<String> variantKeys() {
+            return assets.stream()
+                .map(DefaultCharacterAsset::variantKey)
+                .toList();
+        }
+
+        public Map<String, Integer> variantOrder() {
+            List<String> variantKeys = variantKeys();
+            return variantKeys.stream()
+                .collect(Collectors.toMap(Function.identity(), variantKeys::indexOf));
+        }
+    }
+
+    public record DefaultCharacterAsset(String variantKey, String imageUrl) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record CatalogDocument(List<CatalogEntry> personalities) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record CatalogEntry(
+        String personalityType,
+        String representativeVariantKey,
+        List<AssetEntry> assets
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record AssetEntry(String variantKey, String imageUrl) {
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorCharacterAssetGenerationService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorCharacterAssetGenerationService.java
@@ -1,0 +1,193 @@
+package com.animalleague.april.professor.application;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.lang.Nullable;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.professor.domain.ProfessorCharacterAsset;
+import com.animalleague.april.professor.infrastructure.NanobananaClient;
+import com.animalleague.april.professor.infrastructure.ProfessorCharacterAssetRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorImageStorage;
+
+public class ProfessorCharacterAssetGenerationService {
+
+    private final ProfessorCharacterAssetRepository professorCharacterAssetRepository;
+    private final DefaultCharacterAssetCatalog defaultCharacterAssetCatalog;
+    private final NanobananaClient nanobananaClient;
+    private final ProfessorImageStorage professorImageStorage;
+
+    public ProfessorCharacterAssetGenerationService(
+        ProfessorCharacterAssetRepository professorCharacterAssetRepository,
+        DefaultCharacterAssetCatalog defaultCharacterAssetCatalog,
+        NanobananaClient nanobananaClient,
+        ProfessorImageStorage professorImageStorage
+    ) {
+        this.professorCharacterAssetRepository = professorCharacterAssetRepository;
+        this.defaultCharacterAssetCatalog = defaultCharacterAssetCatalog;
+        this.nanobananaClient = nanobananaClient;
+        this.professorImageStorage = professorImageStorage;
+    }
+
+    public ProfessorCharacterAssetGenerationResult initializeAssets(
+        UUID professorId,
+        PersonalityType personalityType,
+        @Nullable String sourcePhotoUrl
+    ) {
+        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
+
+        if (sourcePhotoUrl == null || sourcePhotoUrl.isBlank()) {
+            return fallbackToDefaultAssets(professorId, personalityType);
+        }
+
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet defaultAssetSet =
+            defaultCharacterAssetCatalog.getAssetSet(personalityType);
+
+        nanobananaClient.requestCharacterAssetGeneration(
+            new NanobananaClient.CharacterAssetGenerationRequest(
+                professorId,
+                personalityType,
+                sourcePhotoUrl,
+                defaultAssetSet.variantKeys()
+            )
+        );
+
+        return ProfessorCharacterAssetGenerationResult.pending();
+    }
+
+    public ProfessorCharacterAssetGenerationResult completeGeneration(
+        UUID professorId,
+        PersonalityType personalityType,
+        List<GeneratedCharacterAssetPayload> generatedAssets
+    ) {
+        if (generatedAssets == null || generatedAssets.isEmpty()) {
+            return fallbackToDefaultAssets(professorId, personalityType);
+        }
+
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet defaultAssetSet =
+            defaultCharacterAssetCatalog.getAssetSet(personalityType);
+        Map<String, Integer> variantOrder = defaultAssetSet.variantOrder();
+
+        List<ProfessorCharacterAsset> assetsToPersist = generatedAssets.stream()
+            .sorted(assetComparator(variantOrder))
+            .map(asset -> ProfessorCharacterAsset.generated(
+                professorId,
+                asset.variantKey(),
+                professorImageStorage.storeCharacterAsset(
+                    professorId,
+                    asset.variantKey(),
+                    asset.imageBytes(),
+                    asset.contentType()
+                )
+            ))
+            .toList();
+
+        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
+        List<ProfessorCharacterAsset> persistedAssets = professorCharacterAssetRepository.saveAll(assetsToPersist);
+        return readyFromAssets(defaultAssetSet.representativeVariantKey(), false, persistedAssets);
+    }
+
+    public ProfessorCharacterAssetGenerationResult fallbackToDefaultAssets(
+        UUID professorId,
+        PersonalityType personalityType
+    ) {
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet defaultAssetSet =
+            defaultCharacterAssetCatalog.getAssetSet(personalityType);
+
+        List<ProfessorCharacterAsset> fallbackAssets = defaultAssetSet.assets().stream()
+            .map(asset -> ProfessorCharacterAsset.defaultAsset(professorId, asset.variantKey(), asset.imageUrl()))
+            .toList();
+
+        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
+        List<ProfessorCharacterAsset> persistedAssets = professorCharacterAssetRepository.saveAll(fallbackAssets);
+        return readyFromAssets(defaultAssetSet.representativeVariantKey(), true, persistedAssets);
+    }
+
+    private Comparator<GeneratedCharacterAssetPayload> assetComparator(Map<String, Integer> variantOrder) {
+        return Comparator
+            .comparingInt((GeneratedCharacterAssetPayload asset) ->
+                variantOrder.getOrDefault(asset.variantKey(), Integer.MAX_VALUE))
+            .thenComparing(GeneratedCharacterAssetPayload::variantKey);
+    }
+
+    private ProfessorCharacterAssetGenerationResult readyFromAssets(
+        String representativeVariantKey,
+        boolean defaultCharacterAssets,
+        List<ProfessorCharacterAsset> persistedAssets
+    ) {
+        List<CharacterAssetView> characterAssets = persistedAssets.stream()
+            .map(asset -> new CharacterAssetView(
+                asset.getVariantKey(),
+                asset.getImageUrl(),
+                asset.isDefaultAsset()
+            ))
+            .toList();
+
+        String representativeAssetUrl = characterAssets.stream()
+            .filter(asset -> asset.variantKey().equals(representativeVariantKey))
+            .map(CharacterAssetView::imageUrl)
+            .findFirst()
+            .orElseGet(() -> characterAssets.stream()
+                .findFirst()
+                .map(CharacterAssetView::imageUrl)
+                .orElse(null));
+
+        return ProfessorCharacterAssetGenerationResult.ready(
+            representativeAssetUrl,
+            defaultCharacterAssets,
+            characterAssets
+        );
+    }
+
+    public record GeneratedCharacterAssetPayload(
+        String variantKey,
+        byte[] imageBytes,
+        String contentType
+    ) {
+    }
+
+    public record CharacterAssetView(
+        String variantKey,
+        String imageUrl,
+        boolean defaultAsset
+    ) {
+    }
+
+    public record ProfessorCharacterAssetGenerationResult(
+        CharacterAssetStatus characterAssetStatus,
+        @Nullable String representativeAssetUrl,
+        boolean defaultCharacterAssets,
+        List<CharacterAssetView> characterAssets
+    ) {
+
+        public ProfessorCharacterAssetGenerationResult {
+            characterAssets = List.copyOf(characterAssets);
+        }
+
+        public static ProfessorCharacterAssetGenerationResult pending() {
+            return new ProfessorCharacterAssetGenerationResult(
+                CharacterAssetStatus.PENDING,
+                null,
+                false,
+                List.of()
+            );
+        }
+
+        public static ProfessorCharacterAssetGenerationResult ready(
+            @Nullable String representativeAssetUrl,
+            boolean defaultCharacterAssets,
+            List<CharacterAssetView> characterAssets
+        ) {
+            return new ProfessorCharacterAssetGenerationResult(
+                CharacterAssetStatus.READY,
+                representativeAssetUrl,
+                defaultCharacterAssets,
+                characterAssets
+            );
+        }
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorCharacterAssetGenerationService.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/application/ProfessorCharacterAssetGenerationService.java
@@ -3,9 +3,11 @@ package com.animalleague.april.professor.application;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.lang.Nullable;
+import org.springframework.transaction.support.TransactionOperations;
 
 import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.PersonalityType;
@@ -20,17 +22,20 @@ public class ProfessorCharacterAssetGenerationService {
     private final DefaultCharacterAssetCatalog defaultCharacterAssetCatalog;
     private final NanobananaClient nanobananaClient;
     private final ProfessorImageStorage professorImageStorage;
+    private final TransactionOperations transactionOperations;
 
     public ProfessorCharacterAssetGenerationService(
         ProfessorCharacterAssetRepository professorCharacterAssetRepository,
         DefaultCharacterAssetCatalog defaultCharacterAssetCatalog,
         NanobananaClient nanobananaClient,
-        ProfessorImageStorage professorImageStorage
+        ProfessorImageStorage professorImageStorage,
+        TransactionOperations transactionOperations
     ) {
         this.professorCharacterAssetRepository = professorCharacterAssetRepository;
         this.defaultCharacterAssetCatalog = defaultCharacterAssetCatalog;
         this.nanobananaClient = nanobananaClient;
         this.professorImageStorage = professorImageStorage;
+        this.transactionOperations = transactionOperations;
     }
 
     public ProfessorCharacterAssetGenerationResult initializeAssets(
@@ -38,8 +43,6 @@ public class ProfessorCharacterAssetGenerationService {
         PersonalityType personalityType,
         @Nullable String sourcePhotoUrl
     ) {
-        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
-
         if (sourcePhotoUrl == null || sourcePhotoUrl.isBlank()) {
             return fallbackToDefaultAssets(professorId, personalityType);
         }
@@ -47,14 +50,20 @@ public class ProfessorCharacterAssetGenerationService {
         DefaultCharacterAssetCatalog.DefaultCharacterAssetSet defaultAssetSet =
             defaultCharacterAssetCatalog.getAssetSet(personalityType);
 
-        nanobananaClient.requestCharacterAssetGeneration(
-            new NanobananaClient.CharacterAssetGenerationRequest(
-                professorId,
-                personalityType,
-                sourcePhotoUrl,
-                defaultAssetSet.variantKeys()
-            )
-        );
+        try {
+            nanobananaClient.requestCharacterAssetGeneration(
+                new NanobananaClient.CharacterAssetGenerationRequest(
+                    professorId,
+                    personalityType,
+                    sourcePhotoUrl,
+                    defaultAssetSet.variantKeys()
+                )
+            );
+        } catch (RuntimeException exception) {
+            return fallbackToDefaultAssets(professorId, personalityType);
+        }
+
+        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
 
         return ProfessorCharacterAssetGenerationResult.pending();
     }
@@ -86,8 +95,7 @@ public class ProfessorCharacterAssetGenerationService {
             ))
             .toList();
 
-        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
-        List<ProfessorCharacterAsset> persistedAssets = professorCharacterAssetRepository.saveAll(assetsToPersist);
+        List<ProfessorCharacterAsset> persistedAssets = replaceAssets(professorId, assetsToPersist);
         return readyFromAssets(defaultAssetSet.representativeVariantKey(), false, persistedAssets);
     }
 
@@ -102,9 +110,21 @@ public class ProfessorCharacterAssetGenerationService {
             .map(asset -> ProfessorCharacterAsset.defaultAsset(professorId, asset.variantKey(), asset.imageUrl()))
             .toList();
 
-        professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
-        List<ProfessorCharacterAsset> persistedAssets = professorCharacterAssetRepository.saveAll(fallbackAssets);
+        List<ProfessorCharacterAsset> persistedAssets = replaceAssets(professorId, fallbackAssets);
         return readyFromAssets(defaultAssetSet.representativeVariantKey(), true, persistedAssets);
+    }
+
+    private List<ProfessorCharacterAsset> replaceAssets(
+        UUID professorId,
+        List<ProfessorCharacterAsset> assetsToPersist
+    ) {
+        return Objects.requireNonNull(
+            transactionOperations.execute(status -> {
+                professorCharacterAssetRepository.deleteAllByProfessorId(professorId);
+                return professorCharacterAssetRepository.saveAll(assetsToPersist);
+            }),
+            "Professor character asset replacement transaction must return persisted assets."
+        );
     }
 
     private Comparator<GeneratedCharacterAssetPayload> assetComparator(Map<String, Integer> variantOrder) {

--- a/Backend/src/main/java/com/animalleague/april/professor/domain/ProfessorCharacterAsset.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/domain/ProfessorCharacterAsset.java
@@ -1,0 +1,108 @@
+package com.animalleague.april.professor.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+    name = "professor_character_assets",
+    indexes = {
+        @Index(name = "idx_professor_character_assets_professor_id", columnList = "professor_id")
+    },
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_professor_character_assets_professor_variant",
+            columnNames = {"professor_id", "variant_key"}
+        )
+    }
+)
+@EntityListeners(AuditingEntityListener.class)
+public class ProfessorCharacterAsset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "professor_id", nullable = false)
+    private UUID professorId;
+
+    @Column(name = "variant_key", nullable = false, length = 100)
+    private String variantKey;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "is_default_asset", nullable = false)
+    private boolean defaultAsset;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected ProfessorCharacterAsset() {
+    }
+
+    private ProfessorCharacterAsset(
+        UUID professorId,
+        String variantKey,
+        String imageUrl,
+        boolean defaultAsset
+    ) {
+        this.professorId = professorId;
+        this.variantKey = variantKey;
+        this.imageUrl = imageUrl;
+        this.defaultAsset = defaultAsset;
+    }
+
+    public static ProfessorCharacterAsset generated(
+        UUID professorId,
+        String variantKey,
+        String imageUrl
+    ) {
+        return new ProfessorCharacterAsset(professorId, variantKey, imageUrl, false);
+    }
+
+    public static ProfessorCharacterAsset defaultAsset(
+        UUID professorId,
+        String variantKey,
+        String imageUrl
+    ) {
+        return new ProfessorCharacterAsset(professorId, variantKey, imageUrl, true);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getProfessorId() {
+        return professorId;
+    }
+
+    public String getVariantKey() {
+        return variantKey;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public boolean isDefaultAsset() {
+        return defaultAsset;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/infrastructure/NanobananaClient.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/infrastructure/NanobananaClient.java
@@ -1,0 +1,22 @@
+package com.animalleague.april.professor.infrastructure;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.animalleague.april.common.domain.PersonalityType;
+
+public interface NanobananaClient {
+
+    GenerationTicket requestCharacterAssetGeneration(CharacterAssetGenerationRequest request);
+
+    record CharacterAssetGenerationRequest(
+        UUID professorId,
+        PersonalityType personalityType,
+        String sourcePhotoUrl,
+        List<String> variantKeys
+    ) {
+    }
+
+    record GenerationTicket(String requestId) {
+    }
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorCharacterAssetRepository.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorCharacterAssetRepository.java
@@ -1,0 +1,15 @@
+package com.animalleague.april.professor.infrastructure;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.animalleague.april.professor.domain.ProfessorCharacterAsset;
+
+public interface ProfessorCharacterAssetRepository extends JpaRepository<ProfessorCharacterAsset, UUID> {
+
+    void deleteAllByProfessorId(UUID professorId);
+
+    List<ProfessorCharacterAsset> findAllByProfessorIdOrderByVariantKey(UUID professorId);
+}

--- a/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorImageStorage.java
+++ b/Backend/src/main/java/com/animalleague/april/professor/infrastructure/ProfessorImageStorage.java
@@ -1,0 +1,13 @@
+package com.animalleague.april.professor.infrastructure;
+
+import java.util.UUID;
+
+public interface ProfessorImageStorage {
+
+    String storeCharacterAsset(
+        UUID professorId,
+        String variantKey,
+        byte[] imageBytes,
+        String contentType
+    );
+}

--- a/Backend/src/main/resources/db/migration/V3__create_professor_character_assets_table.sql
+++ b/Backend/src/main/resources/db/migration/V3__create_professor_character_assets_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE professor_character_assets (
+    id UUID PRIMARY KEY,
+    professor_id UUID NOT NULL,
+    variant_key VARCHAR(100) NOT NULL,
+    image_url TEXT NOT NULL,
+    is_default_asset BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_professor_character_assets_professor_variant UNIQUE (professor_id, variant_key)
+);
+
+CREATE INDEX idx_professor_character_assets_professor_id
+    ON professor_character_assets (professor_id);

--- a/Backend/src/main/resources/seed/characters/default-character-assets.json
+++ b/Backend/src/main/resources/seed/characters/default-character-assets.json
@@ -1,0 +1,76 @@
+{
+  "personalities": [
+    {
+      "personalityType": "gentle",
+      "representativeVariantKey": "idle_neutral",
+      "assets": [
+        {
+          "variantKey": "idle_neutral",
+          "imageUrl": "https://cdn.example.com/assets/default/gentle/idle_neutral.png"
+        },
+        {
+          "variantKey": "idle_smile",
+          "imageUrl": "https://cdn.example.com/assets/default/gentle/idle_smile.png"
+        },
+        {
+          "variantKey": "study_focus",
+          "imageUrl": "https://cdn.example.com/assets/default/gentle/study_focus.png"
+        }
+      ]
+    },
+    {
+      "personalityType": "tsundere",
+      "representativeVariantKey": "idle_neutral",
+      "assets": [
+        {
+          "variantKey": "idle_neutral",
+          "imageUrl": "https://cdn.example.com/assets/default/tsundere/idle_neutral.png"
+        },
+        {
+          "variantKey": "idle_smile",
+          "imageUrl": "https://cdn.example.com/assets/default/tsundere/idle_smile.png"
+        },
+        {
+          "variantKey": "study_focus",
+          "imageUrl": "https://cdn.example.com/assets/default/tsundere/study_focus.png"
+        }
+      ]
+    },
+    {
+      "personalityType": "english_mix",
+      "representativeVariantKey": "idle_neutral",
+      "assets": [
+        {
+          "variantKey": "idle_neutral",
+          "imageUrl": "https://cdn.example.com/assets/default/english_mix/idle_neutral.png"
+        },
+        {
+          "variantKey": "idle_smile",
+          "imageUrl": "https://cdn.example.com/assets/default/english_mix/idle_smile.png"
+        },
+        {
+          "variantKey": "study_focus",
+          "imageUrl": "https://cdn.example.com/assets/default/english_mix/study_focus.png"
+        }
+      ]
+    },
+    {
+      "personalityType": "shy",
+      "representativeVariantKey": "idle_neutral",
+      "assets": [
+        {
+          "variantKey": "idle_neutral",
+          "imageUrl": "https://cdn.example.com/assets/default/shy/idle_neutral.png"
+        },
+        {
+          "variantKey": "idle_smile",
+          "imageUrl": "https://cdn.example.com/assets/default/shy/idle_smile.png"
+        },
+        {
+          "variantKey": "study_focus",
+          "imageUrl": "https://cdn.example.com/assets/default/shy/study_focus.png"
+        }
+      ]
+    }
+  ]
+}

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorCharacterAssetGenerationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorCharacterAssetGenerationIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.animalleague.april.integration.professor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.integration.support.PostgresIntegrationTest;
+import com.animalleague.april.professor.application.DefaultCharacterAssetCatalog;
+import com.animalleague.april.professor.application.ProfessorCharacterAssetGenerationService;
+import com.animalleague.april.professor.infrastructure.NanobananaClient;
+import com.animalleague.april.professor.infrastructure.ProfessorCharacterAssetRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorImageStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class ProfessorCharacterAssetGenerationIntegrationTest extends PostgresIntegrationTest {
+
+    @Autowired
+    private ProfessorCharacterAssetRepository professorCharacterAssetRepository;
+
+    @Autowired
+    private DefaultCharacterAssetCatalog defaultCharacterAssetCatalog;
+
+    private RecordingNanobananaClient nanobananaClient;
+    private DeterministicProfessorImageStorage professorImageStorage;
+    private ProfessorCharacterAssetGenerationService service;
+
+    @BeforeEach
+    void setUpService() {
+        nanobananaClient = new RecordingNanobananaClient();
+        professorImageStorage = new DeterministicProfessorImageStorage();
+        service = new ProfessorCharacterAssetGenerationService(
+            professorCharacterAssetRepository,
+            defaultCharacterAssetCatalog,
+            nanobananaClient,
+            professorImageStorage
+        );
+    }
+
+    @Test
+    void sourcePhotoStartsPendingThenTransitionsToReadyWithRepresentativeAsset() {
+        UUID professorId = UUID.randomUUID();
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult pendingResult =
+            service.initializeAssets(
+                professorId,
+                PersonalityType.GENTLE,
+                "https://cdn.example.com/source/professor.png"
+            );
+
+        assertThat(pendingResult.characterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
+        assertThat(pendingResult.representativeAssetUrl()).isNull();
+        assertThat(pendingResult.defaultCharacterAssets()).isFalse();
+        assertThat(professorCharacterAssetRepository.findAllByProfessorIdOrderByVariantKey(professorId)).isEmpty();
+        assertThat(nanobananaClient.requests).singleElement().satisfies(request -> {
+            assertThat(request.professorId()).isEqualTo(professorId);
+            assertThat(request.variantKeys()).containsExactly("idle_neutral", "idle_smile", "study_focus");
+        });
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult readyResult =
+            service.completeGeneration(
+                professorId,
+                PersonalityType.GENTLE,
+                List.of(
+                    new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                        "idle_smile",
+                        "smile".getBytes(StandardCharsets.UTF_8),
+                        "image/png"
+                    ),
+                    new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                        "idle_neutral",
+                        "neutral".getBytes(StandardCharsets.UTF_8),
+                        "image/png"
+                    )
+                )
+            );
+
+        assertThat(readyResult.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(readyResult.defaultCharacterAssets()).isFalse();
+        assertThat(readyResult.representativeAssetUrl())
+            .isEqualTo("https://cdn.test/generated/" + professorId + "/idle_neutral.png");
+        assertThat(readyResult.characterAssets())
+            .extracting(ProfessorCharacterAssetGenerationService.CharacterAssetView::variantKey)
+            .containsExactly("idle_neutral", "idle_smile");
+        assertThat(professorCharacterAssetRepository.findAllByProfessorIdOrderByVariantKey(professorId))
+            .extracting(asset -> asset.getImageUrl())
+            .containsExactly(
+                "https://cdn.test/generated/" + professorId + "/idle_neutral.png",
+                "https://cdn.test/generated/" + professorId + "/idle_smile.png"
+            );
+    }
+
+    @Test
+    void generationFailureStoresDefaultFallbackAssetsAndRepresentative() {
+        UUID professorId = UUID.randomUUID();
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.fallbackToDefaultAssets(professorId, PersonalityType.SHY);
+
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(result.defaultCharacterAssets()).isTrue();
+        assertThat(result.representativeAssetUrl())
+            .isEqualTo("https://cdn.example.com/assets/default/shy/idle_neutral.png");
+        assertThat(result.characterAssets())
+            .extracting(ProfessorCharacterAssetGenerationService.CharacterAssetView::variantKey)
+            .containsExactly("idle_neutral", "idle_smile", "study_focus");
+        assertThat(professorCharacterAssetRepository.findAllByProfessorIdOrderByVariantKey(professorId))
+            .hasSize(3)
+            .allMatch(asset -> asset.isDefaultAsset());
+    }
+
+    private static final class RecordingNanobananaClient implements NanobananaClient {
+
+        private final List<CharacterAssetGenerationRequest> requests = new ArrayList<>();
+
+        @Override
+        public GenerationTicket requestCharacterAssetGeneration(CharacterAssetGenerationRequest request) {
+            requests.add(request);
+            return new GenerationTicket("ticket-" + requests.size());
+        }
+    }
+
+    private static final class DeterministicProfessorImageStorage implements ProfessorImageStorage {
+
+        @Override
+        public String storeCharacterAsset(
+            UUID professorId,
+            String variantKey,
+            byte[] imageBytes,
+            String contentType
+        ) {
+            return "https://cdn.test/generated/" + professorId + "/" + variantKey + ".png";
+        }
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorCharacterAssetGenerationIntegrationTest.java
+++ b/Backend/src/test/java/com/animalleague/april/integration/professor/ProfessorCharacterAssetGenerationIntegrationTest.java
@@ -8,7 +8,11 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.PersonalityType;
@@ -20,6 +24,7 @@ import com.animalleague.april.professor.infrastructure.ProfessorCharacterAssetRe
 import com.animalleague.april.professor.infrastructure.ProfessorImageStorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 class ProfessorCharacterAssetGenerationIntegrationTest extends PostgresIntegrationTest {
@@ -29,6 +34,9 @@ class ProfessorCharacterAssetGenerationIntegrationTest extends PostgresIntegrati
 
     @Autowired
     private DefaultCharacterAssetCatalog defaultCharacterAssetCatalog;
+
+    @Autowired
+    private TransactionOperations transactionOperations;
 
     private RecordingNanobananaClient nanobananaClient;
     private DeterministicProfessorImageStorage professorImageStorage;
@@ -42,7 +50,8 @@ class ProfessorCharacterAssetGenerationIntegrationTest extends PostgresIntegrati
             professorCharacterAssetRepository,
             defaultCharacterAssetCatalog,
             nanobananaClient,
-            professorImageStorage
+            professorImageStorage,
+            transactionOperations
         );
     }
 
@@ -118,14 +127,76 @@ class ProfessorCharacterAssetGenerationIntegrationTest extends PostgresIntegrati
             .allMatch(asset -> asset.isDefaultAsset());
     }
 
+    @Test
+    void sourcePhotoRequestFailureFallsBackToDefaultAssets() {
+        UUID professorId = UUID.randomUUID();
+        nanobananaClient.failNextRequest();
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.initializeAssets(
+                professorId,
+                PersonalityType.GENTLE,
+                "https://cdn.example.com/source/professor.png"
+            );
+
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(result.defaultCharacterAssets()).isTrue();
+        assertThat(result.representativeAssetUrl())
+            .isEqualTo("https://cdn.example.com/assets/default/gentle/idle_neutral.png");
+        assertThat(professorCharacterAssetRepository.findAllByProfessorIdOrderByVariantKey(professorId))
+            .hasSize(3)
+            .allMatch(asset -> asset.isDefaultAsset());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void failedAssetReplacementRollsBackDeleteAndKeepsExistingAssets() {
+        UUID professorId = UUID.randomUUID();
+        service.fallbackToDefaultAssets(professorId, PersonalityType.GENTLE);
+
+        assertThatThrownBy(() -> service.completeGeneration(
+            professorId,
+            PersonalityType.GENTLE,
+            List.of(
+                new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                    "idle_smile",
+                    "first".getBytes(StandardCharsets.UTF_8),
+                    "image/png"
+                ),
+                new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                    "idle_smile",
+                    "second".getBytes(StandardCharsets.UTF_8),
+                    "image/png"
+                )
+            )
+        )).isInstanceOf(DataAccessException.class);
+
+        assertThat(professorCharacterAssetRepository.findAllByProfessorIdOrderByVariantKey(professorId))
+            .extracting(asset -> asset.getVariantKey() + ":" + asset.getImageUrl())
+            .containsExactly(
+                "idle_neutral:https://cdn.example.com/assets/default/gentle/idle_neutral.png",
+                "idle_smile:https://cdn.example.com/assets/default/gentle/idle_smile.png",
+                "study_focus:https://cdn.example.com/assets/default/gentle/study_focus.png"
+            );
+    }
+
     private static final class RecordingNanobananaClient implements NanobananaClient {
 
         private final List<CharacterAssetGenerationRequest> requests = new ArrayList<>();
+        private boolean failNextRequest;
 
         @Override
         public GenerationTicket requestCharacterAssetGeneration(CharacterAssetGenerationRequest request) {
+            if (failNextRequest) {
+                failNextRequest = false;
+                throw new IllegalStateException("nanobanana unavailable");
+            }
             requests.add(request);
             return new GenerationTicket("ticket-" + requests.size());
+        }
+
+        private void failNextRequest() {
+            this.failNextRequest = true;
         }
     }
 

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/ProfessorCharacterAssetGenerationServiceUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/ProfessorCharacterAssetGenerationServiceUnitTest.java
@@ -1,0 +1,173 @@
+package com.animalleague.april.unit.professor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.animalleague.april.common.domain.CharacterAssetStatus;
+import com.animalleague.april.common.domain.PersonalityType;
+import com.animalleague.april.professor.application.DefaultCharacterAssetCatalog;
+import com.animalleague.april.professor.application.ProfessorCharacterAssetGenerationService;
+import com.animalleague.april.professor.domain.ProfessorCharacterAsset;
+import com.animalleague.april.professor.infrastructure.NanobananaClient;
+import com.animalleague.april.professor.infrastructure.ProfessorCharacterAssetRepository;
+import com.animalleague.april.professor.infrastructure.ProfessorImageStorage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class ProfessorCharacterAssetGenerationServiceUnitTest {
+
+    private final ProfessorCharacterAssetRepository professorCharacterAssetRepository =
+        mock(ProfessorCharacterAssetRepository.class);
+    private final DefaultCharacterAssetCatalog defaultCharacterAssetCatalog =
+        mock(DefaultCharacterAssetCatalog.class);
+    private final NanobananaClient nanobananaClient = mock(NanobananaClient.class);
+    private final ProfessorImageStorage professorImageStorage = mock(ProfessorImageStorage.class);
+
+    private ProfessorCharacterAssetGenerationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProfessorCharacterAssetGenerationService(
+            professorCharacterAssetRepository,
+            defaultCharacterAssetCatalog,
+            nanobananaClient,
+            professorImageStorage
+        );
+    }
+
+    @Test
+    void sourcePhotoRequestsNanobananaAndReturnsPending() {
+        UUID professorId = UUID.randomUUID();
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet gentleAssetSet = gentleAssetSet();
+        given(defaultCharacterAssetCatalog.getAssetSet(PersonalityType.GENTLE)).willReturn(gentleAssetSet);
+        given(nanobananaClient.requestCharacterAssetGeneration(any()))
+            .willReturn(new NanobananaClient.GenerationTicket("ticket-1"));
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.initializeAssets(
+                professorId,
+                PersonalityType.GENTLE,
+                "https://cdn.example.com/source/professor.png"
+            );
+
+        ArgumentCaptor<NanobananaClient.CharacterAssetGenerationRequest> requestCaptor =
+            ArgumentCaptor.forClass(NanobananaClient.CharacterAssetGenerationRequest.class);
+        verify(nanobananaClient).requestCharacterAssetGeneration(requestCaptor.capture());
+        verify(professorCharacterAssetRepository, never()).saveAll(any());
+
+        assertThat(requestCaptor.getValue().professorId()).isEqualTo(professorId);
+        assertThat(requestCaptor.getValue().personalityType()).isEqualTo(PersonalityType.GENTLE);
+        assertThat(requestCaptor.getValue().variantKeys())
+            .containsExactly("idle_neutral", "idle_smile", "study_focus");
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.PENDING);
+        assertThat(result.representativeAssetUrl()).isNull();
+        assertThat(result.defaultCharacterAssets()).isFalse();
+        assertThat(result.characterAssets()).isEmpty();
+    }
+
+    @Test
+    void completeGenerationStoresGeneratedAssetsAndSelectsRepresentativeVariant() {
+        UUID professorId = UUID.randomUUID();
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet gentleAssetSet = gentleAssetSet();
+        AtomicReference<List<ProfessorCharacterAsset>> savedAssets = new AtomicReference<>();
+        given(defaultCharacterAssetCatalog.getAssetSet(PersonalityType.GENTLE)).willReturn(gentleAssetSet);
+        given(professorImageStorage.storeCharacterAsset(eq(professorId), eq("idle_smile"), any(), eq("image/png")))
+            .willReturn("https://cdn.example.com/generated/professor/idle_smile.png");
+        given(professorImageStorage.storeCharacterAsset(eq(professorId), eq("idle_neutral"), any(), eq("image/png")))
+            .willReturn("https://cdn.example.com/generated/professor/idle_neutral.png");
+        given(professorCharacterAssetRepository.saveAll(any())).willAnswer(invocation -> {
+            List<ProfessorCharacterAsset> assets = invocation.getArgument(0);
+            savedAssets.set(assets);
+            return assets;
+        });
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.completeGeneration(
+                professorId,
+                PersonalityType.GENTLE,
+                List.of(
+                    new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                        "idle_smile",
+                        "smile".getBytes(StandardCharsets.UTF_8),
+                        "image/png"
+                    ),
+                    new ProfessorCharacterAssetGenerationService.GeneratedCharacterAssetPayload(
+                        "idle_neutral",
+                        "neutral".getBytes(StandardCharsets.UTF_8),
+                        "image/png"
+                    )
+                )
+            );
+
+        assertThat(savedAssets.get())
+            .extracting(ProfessorCharacterAsset::getVariantKey)
+            .containsExactly("idle_neutral", "idle_smile");
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(result.representativeAssetUrl())
+            .isEqualTo("https://cdn.example.com/generated/professor/idle_neutral.png");
+        assertThat(result.defaultCharacterAssets()).isFalse();
+        assertThat(result.characterAssets())
+            .extracting(ProfessorCharacterAssetGenerationService.CharacterAssetView::variantKey)
+            .containsExactly("idle_neutral", "idle_smile");
+    }
+
+    @Test
+    void generationFailureFallsBackToDefaultAssets() {
+        UUID professorId = UUID.randomUUID();
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet gentleAssetSet = gentleAssetSet();
+        AtomicReference<List<ProfessorCharacterAsset>> savedAssets = new AtomicReference<>();
+        given(defaultCharacterAssetCatalog.getAssetSet(PersonalityType.GENTLE)).willReturn(gentleAssetSet);
+        given(professorCharacterAssetRepository.saveAll(any())).willAnswer(invocation -> {
+            List<ProfessorCharacterAsset> assets = invocation.getArgument(0);
+            savedAssets.set(assets);
+            return assets;
+        });
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.fallbackToDefaultAssets(professorId, PersonalityType.GENTLE);
+
+        assertThat(savedAssets.get())
+            .extracting(ProfessorCharacterAsset::isDefaultAsset)
+            .containsOnly(true);
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(result.representativeAssetUrl())
+            .isEqualTo("https://cdn.example.com/assets/default/gentle/idle_neutral.png");
+        assertThat(result.defaultCharacterAssets()).isTrue();
+        assertThat(result.characterAssets())
+            .extracting(ProfessorCharacterAssetGenerationService.CharacterAssetView::variantKey)
+            .containsExactly("idle_neutral", "idle_smile", "study_focus");
+    }
+
+    private DefaultCharacterAssetCatalog.DefaultCharacterAssetSet gentleAssetSet() {
+        return new DefaultCharacterAssetCatalog.DefaultCharacterAssetSet(
+            PersonalityType.GENTLE,
+            "idle_neutral",
+            List.of(
+                new DefaultCharacterAssetCatalog.DefaultCharacterAsset(
+                    "idle_neutral",
+                    "https://cdn.example.com/assets/default/gentle/idle_neutral.png"
+                ),
+                new DefaultCharacterAssetCatalog.DefaultCharacterAsset(
+                    "idle_smile",
+                    "https://cdn.example.com/assets/default/gentle/idle_smile.png"
+                ),
+                new DefaultCharacterAssetCatalog.DefaultCharacterAsset(
+                    "study_focus",
+                    "https://cdn.example.com/assets/default/gentle/study_focus.png"
+                )
+            )
+        );
+    }
+}

--- a/Backend/src/test/java/com/animalleague/april/unit/professor/ProfessorCharacterAssetGenerationServiceUnitTest.java
+++ b/Backend/src/test/java/com/animalleague/april/unit/professor/ProfessorCharacterAssetGenerationServiceUnitTest.java
@@ -8,6 +8,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionOperations;
 
 import com.animalleague.april.common.domain.CharacterAssetStatus;
 import com.animalleague.april.common.domain.PersonalityType;
@@ -34,6 +37,12 @@ class ProfessorCharacterAssetGenerationServiceUnitTest {
         mock(DefaultCharacterAssetCatalog.class);
     private final NanobananaClient nanobananaClient = mock(NanobananaClient.class);
     private final ProfessorImageStorage professorImageStorage = mock(ProfessorImageStorage.class);
+    private final TransactionOperations transactionOperations = new TransactionOperations() {
+        @Override
+        public <T> T execute(TransactionCallback<T> action) {
+            return action.doInTransaction(new SimpleTransactionStatus());
+        }
+    };
 
     private ProfessorCharacterAssetGenerationService service;
 
@@ -43,7 +52,8 @@ class ProfessorCharacterAssetGenerationServiceUnitTest {
             professorCharacterAssetRepository,
             defaultCharacterAssetCatalog,
             nanobananaClient,
-            professorImageStorage
+            professorImageStorage,
+            transactionOperations
         );
     }
 
@@ -65,6 +75,7 @@ class ProfessorCharacterAssetGenerationServiceUnitTest {
         ArgumentCaptor<NanobananaClient.CharacterAssetGenerationRequest> requestCaptor =
             ArgumentCaptor.forClass(NanobananaClient.CharacterAssetGenerationRequest.class);
         verify(nanobananaClient).requestCharacterAssetGeneration(requestCaptor.capture());
+        verify(professorCharacterAssetRepository).deleteAllByProfessorId(professorId);
         verify(professorCharacterAssetRepository, never()).saveAll(any());
 
         assertThat(requestCaptor.getValue().professorId()).isEqualTo(professorId);
@@ -75,6 +86,36 @@ class ProfessorCharacterAssetGenerationServiceUnitTest {
         assertThat(result.representativeAssetUrl()).isNull();
         assertThat(result.defaultCharacterAssets()).isFalse();
         assertThat(result.characterAssets()).isEmpty();
+    }
+
+    @Test
+    void sourcePhotoGenerationRequestFailureFallsBackToDefaultAssets() {
+        UUID professorId = UUID.randomUUID();
+        DefaultCharacterAssetCatalog.DefaultCharacterAssetSet gentleAssetSet = gentleAssetSet();
+        AtomicReference<List<ProfessorCharacterAsset>> savedAssets = new AtomicReference<>();
+        given(defaultCharacterAssetCatalog.getAssetSet(PersonalityType.GENTLE)).willReturn(gentleAssetSet);
+        given(nanobananaClient.requestCharacterAssetGeneration(any()))
+            .willThrow(new IllegalStateException("nanobanana timeout"));
+        given(professorCharacterAssetRepository.saveAll(any())).willAnswer(invocation -> {
+            List<ProfessorCharacterAsset> assets = invocation.getArgument(0);
+            savedAssets.set(assets);
+            return assets;
+        });
+
+        ProfessorCharacterAssetGenerationService.ProfessorCharacterAssetGenerationResult result =
+            service.initializeAssets(
+                professorId,
+                PersonalityType.GENTLE,
+                "https://cdn.example.com/source/professor.png"
+            );
+
+        assertThat(savedAssets.get())
+            .extracting(ProfessorCharacterAsset::isDefaultAsset)
+            .containsOnly(true);
+        assertThat(result.characterAssetStatus()).isEqualTo(CharacterAssetStatus.READY);
+        assertThat(result.defaultCharacterAssets()).isTrue();
+        assertThat(result.representativeAssetUrl())
+            .isEqualTo("https://cdn.example.com/assets/default/gentle/idle_neutral.png");
     }
 
     @Test


### PR DESCRIPTION
## 요약

- 교수 캐릭터 에셋 생성 전용 도메인/저장소/서비스 포트를 추가했습니다.
- 기본 캐릭터 에셋 카탈로그와 `V3` 마이그레이션을 추가했습니다.
- `nanobanana` 요청, `pending -> ready` 전이, fallback 규칙을 unit/integration test로 검증했습니다.

## 연결된 이슈

- Closes #5

## 변경 내용

- `ProfessorCharacterAsset`, `ProfessorCharacterAssetRepository`로 교수 캐릭터 에셋 영속 모델을 추가했습니다.
- `NanobananaClient`, `ProfessorImageStorage` 포트를 분리해 등록 API 코어와 생성 파이프라인 경계를 나눴습니다.
- `ProfessorCharacterAssetGenerationService`에서 다음 흐름을 구현했습니다.
  - 원본 사진이 있으면 생성 요청 후 `pending` 반환
  - 생성 완료 시 저장소/스토리지를 통해 대표 에셋 선택 후 `ready` 반환
  - 사진이 없거나 생성 실패면 기본 에셋 세트로 fallback
- `default-character-assets.json`, `DefaultCharacterAssetCatalog`로 성격별 기본 에셋 세트를 로딩하도록 했습니다.
- `V3__create_professor_character_assets_table.sql`로 에셋 테이블, 인덱스, `(professor_id, variant_key)` 유니크 제약을 추가했습니다.

## 테스트

- `JAVA_HOME=/tmp/temurin21 PATH=/tmp/temurin21/bin:$PATH GRADLE_USER_HOME=/tmp/animalleague-gradle-home ./gradlew --no-daemon unitTest --tests "*ProfessorCharacterAssetGenerationServiceUnitTest"`
- `JAVA_HOME=/tmp/temurin21 PATH=/tmp/temurin21/bin:$PATH GRADLE_USER_HOME=/tmp/animalleague-gradle-home ./gradlew --no-daemon integrationTest --tests "*ProfessorCharacterAssetGenerationIntegrationTest"`

## 메모

- 현재 `main` 기준에는 `#4`의 `professors` 테이블이 아직 없어서 `V3`는 `professor_id` 컬럼과 인덱스/유니크 제약까지만 먼저 정의했습니다.
- `#4` 머지 후 FK 연결과 등록 API 통합은 그 작업과 맞물려 이어지면 됩니다.

## Summary by Sourcery

Introduce a professor character asset generation pipeline with support for AI-based generation and default asset fallback, backed by persistent storage.

New Features:
- Add a service to initialize, complete, and fallback professor character asset generation, including pending/ready statuses and representative asset selection.
- Introduce a default character asset catalog loaded from JSON to provide per-personality default asset sets and ordering.
- Define ports for an external Nanobanana generation client and professor image storage to decouple generation and storage concerns.
- Add a JPA entity and repository for professor character assets with per-professor variant uniqueness and creation timestamp auditing.

Tests:
- Add unit tests covering Nanobanana request triggering, generation completion, and default fallback behavior for the professor character asset generation service.
- Add integration tests verifying pending-to-ready transitions, persistence of generated assets, and storage of default fallback assets in PostgreSQL.